### PR TITLE
Fix dynamic reducer creation and slash delimeters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-      "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -84,9 +84,9 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-regex": {
@@ -114,7 +114,7 @@
       "dev": true,
       "requires": {
         "delegates": "1.0.0",
-        "readable-stream": "2.3.5"
+        "readable-stream": "2.3.6"
       }
     },
     "argparse": {
@@ -215,6 +215,12 @@
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -324,9 +330,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
       "dev": true
     },
     "circular-json": {
@@ -372,9 +378,9 @@
       }
     },
     "clone": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "cmd-shim": {
@@ -458,13 +464,14 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
+        "buffer-from": "1.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
       }
     },
@@ -475,22 +482,22 @@
       "dev": true
     },
     "conventional-changelog": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.18.tgz",
-      "integrity": "sha512-swf5bqhm7PsY2cw6zxuPy6+rZiiGwEpQnrWki+L+z2oZI53QSYwU4brpljmmWss821AsiwmVL+7V6hP+ER+TBA==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.23.tgz",
+      "integrity": "sha512-yCPXU/OXJmxgbvTQfIKXKwKa4KQTvlO0a4T/371Raz3bdxcHIGhQtHtdrNee4Z8nGLNfe54njHDblVG2JNFyjg==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "1.6.6",
-        "conventional-changelog-atom": "0.2.4",
-        "conventional-changelog-codemirror": "0.3.4",
-        "conventional-changelog-core": "2.0.5",
-        "conventional-changelog-ember": "0.3.6",
-        "conventional-changelog-eslint": "1.0.5",
-        "conventional-changelog-express": "0.3.4",
+        "conventional-changelog-atom": "0.2.8",
+        "conventional-changelog-codemirror": "0.3.8",
+        "conventional-changelog-core": "2.0.10",
+        "conventional-changelog-ember": "0.3.11",
+        "conventional-changelog-eslint": "1.0.9",
+        "conventional-changelog-express": "0.3.6",
         "conventional-changelog-jquery": "0.1.0",
         "conventional-changelog-jscs": "0.1.0",
-        "conventional-changelog-jshint": "0.3.4",
-        "conventional-changelog-preset-loader": "1.1.6"
+        "conventional-changelog-jshint": "0.3.8",
+        "conventional-changelog-preset-loader": "1.1.8"
       }
     },
     "conventional-changelog-angular": {
@@ -504,49 +511,49 @@
       }
     },
     "conventional-changelog-atom": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.4.tgz",
-      "integrity": "sha512-4+hmbBwcAwx1XzDZ4aEOxk/ONU0iay10G0u/sld16ksgnRUHN7CxmZollm3FFaptr6VADMq1qxomA+JlpblBlg==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
+      "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
       "dev": true,
       "requires": {
         "q": "1.5.1"
       }
     },
     "conventional-changelog-cli": {
-      "version": "1.3.16",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.16.tgz",
-      "integrity": "sha512-zNDG/rNbh29Z+d6zzrHN63dFZ4q9k1Ri0V8lXGw1q2ia6+FaE7AqJKccObbBFRmRISXpFESrqZiXpM4QeA84YA==",
+      "version": "1.3.21",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.21.tgz",
+      "integrity": "sha512-K9VBljxzuATZCLTVnI83PN7WdeRJRPPB5FumuLk4ES3E+m2YJvX07DRbdJlINk6C2DeAjj4ioS5JvsvJaaCRbA==",
       "dev": true,
       "requires": {
         "add-stream": "1.0.0",
-        "conventional-changelog": "1.1.18",
+        "conventional-changelog": "1.1.23",
         "lodash": "4.17.5",
         "meow": "4.0.0",
         "tempfile": "1.1.1"
       }
     },
     "conventional-changelog-codemirror": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.4.tgz",
-      "integrity": "sha512-8M7pGgQVzRU//vG3rFlLYqqBywOLxu9XM0/lc1/1Ll7RuKA79PgK9TDpuPmQDHFnqGS7D1YiZpC3Z0D9AIYExg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
+      "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
       "dev": true,
       "requires": {
         "q": "1.5.1"
       }
     },
     "conventional-changelog-core": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.5.tgz",
-      "integrity": "sha512-lP1s7Z3NyEFcG78bWy7GG7nXsq9OpAJgo2xbyAlVBDweLSL5ghvyEZlkEamnAQpIUVK0CAVhs8nPvCiQuXT/VA==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.10.tgz",
+      "integrity": "sha512-FP0NHXIbpvU+f5jk/qZdnodhFmlzKW8ENRHQIWT69oe7ffur9nFRVJZlnXnFBOzwHM9WIRbC15ZWh9HZN6t9Uw==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "3.0.4",
-        "conventional-commits-parser": "2.1.5",
+        "conventional-changelog-writer": "3.0.9",
+        "conventional-commits-parser": "2.1.7",
         "dateformat": "3.0.3",
         "get-pkg-repo": "1.4.0",
-        "git-raw-commits": "1.3.4",
+        "git-raw-commits": "1.3.6",
         "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.3.4",
+        "git-semver-tags": "1.3.6",
         "lodash": "4.17.5",
         "normalize-package-data": "2.4.0",
         "q": "1.5.1",
@@ -611,27 +618,27 @@
       }
     },
     "conventional-changelog-ember": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.6.tgz",
-      "integrity": "sha512-hBM1xb5IrjNtsjXaGryPF/Wn36cwyjkNeqX/CIDbJv/1kRFBHsWoSPYBiNVEpg8xE5fcK4DbPhGTDN2sVoPeiA==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.11.tgz",
+      "integrity": "sha512-ErjPPiDmTd/WPgj2bSp+CGsLtJiv7FbdPKjZXH2Cd5P7j44Rqf0V9SIAAYFTQNoPqmvcp+sIcr/vH52WzPJUbw==",
       "dev": true,
       "requires": {
         "q": "1.5.1"
       }
     },
     "conventional-changelog-eslint": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.5.tgz",
-      "integrity": "sha512-7NUv+gMOS8Y49uPFRgF7kuLZqpnrKa2bQMZZsc62NzvaJmjUktnV03PYHuXhTDEHt5guvV9gyEFtUpgHCDkojg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
+      "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
       "dev": true,
       "requires": {
         "q": "1.5.1"
       }
     },
     "conventional-changelog-express": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.4.tgz",
-      "integrity": "sha512-M+UUb715TXT6l9vyMf4HYvAepnQn0AYTcPi6KHrFsd80E0HErjQnqStBg8i3+Qm7EV9+RyATQEnIhSzHbdQ7+A==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
+      "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
       "dev": true,
       "requires": {
         "q": "1.5.1"
@@ -656,9 +663,9 @@
       }
     },
     "conventional-changelog-jshint": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.4.tgz",
-      "integrity": "sha512-CdrqwDgL56b176FVxHmhuOvnO1dRDQvrMaHyuIVjcFlOXukATz2wVT17g8jQU3LvybVbyXvJRbdD5pboo7/1KQ==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
+      "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
@@ -666,19 +673,19 @@
       }
     },
     "conventional-changelog-preset-loader": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.6.tgz",
-      "integrity": "sha512-yWPIP9wwsCKeUSPYApnApWhKIDjWRIX/uHejGS1tYfEsQR/bwpDFET7LYiHT+ujNbrlf6h1s3NlPGheOd4yJRQ==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
+      "integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.4.tgz",
-      "integrity": "sha512-EUf/hWiEj3IOa5Jk8XDzM6oS0WgijlYGkUfLc+mDnLH9RwpZqhYIBwgJHWHzEB4My013wx2FhmUu45P6tQrucw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
+      "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.1.5",
+        "conventional-commits-filter": "1.1.6",
         "dateformat": "3.0.3",
         "handlebars": "4.0.11",
         "json-stringify-safe": "5.0.1",
@@ -690,19 +697,19 @@
       }
     },
     "conventional-commits-filter": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.5.tgz",
-      "integrity": "sha512-mj3+WLj8UZE72zO9jocZjx8+W4Bwnx/KHoIz1vb4F8XUXj0XSjp8Y3MFkpRyIpsRiCBX+DkDjxGKF/nfeu7BGw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
+      "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
       "dev": true,
       "requires": {
         "is-subset": "0.1.1",
-        "modify-values": "1.0.0"
+        "modify-values": "1.0.1"
       }
     },
     "conventional-commits-parser": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.5.tgz",
-      "integrity": "sha512-jaAP61py+ISMF3/n3yIiIuY5h6mJlucOqawu5mLB1HaQADLvg/y5UB3pT7HSucZJan34lp7+7ylQPfbKEGmxrA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+      "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.2",
@@ -720,11 +727,11 @@
       "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.1",
-        "conventional-commits-filter": "1.1.5",
-        "conventional-commits-parser": "2.1.5",
-        "git-raw-commits": "1.3.4",
-        "git-semver-tags": "1.3.4",
+        "concat-stream": "1.6.2",
+        "conventional-commits-filter": "1.1.6",
+        "conventional-commits-parser": "2.1.7",
+        "git-raw-commits": "1.3.6",
+        "git-semver-tags": "1.3.6",
         "meow": "3.7.0",
         "object-assign": "4.1.1"
       },
@@ -832,7 +839,7 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.2",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
@@ -918,7 +925,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3"
+        "clone": "1.0.4"
       }
     },
     "del": {
@@ -929,7 +936,7 @@
       "requires": {
         "globby": "5.0.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
@@ -1021,32 +1028,32 @@
       }
     },
     "eslint": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
-      "integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.2",
-        "concat-stream": "1.6.1",
+        "concat-stream": "1.6.2",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
         "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.3",
-        "esquery": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.3.0",
+        "globals": "11.4.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.1.0",
-        "js-yaml": "3.10.0",
+        "js-yaml": "3.11.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.5",
@@ -1057,6 +1064,7 @@
         "path-is-inside": "1.0.2",
         "pluralize": "7.0.0",
         "progress": "2.0.0",
+        "regexpp": "1.1.0",
         "require-uncached": "1.0.3",
         "semver": "5.5.0",
         "strip-ansi": "4.0.0",
@@ -1082,12 +1090,12 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
-      "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0",
+        "acorn": "5.5.3",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -1098,9 +1106,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
         "estraverse": "4.2.0"
@@ -1143,9 +1151,9 @@
       }
     },
     "external-editor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -1293,7 +1301,7 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "meow": "3.7.0",
         "normalize-package-data": "2.4.0",
         "parse-github-repo-url": "1.4.1",
@@ -1401,9 +1409,9 @@
       "dev": true
     },
     "git-raw-commits": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.4.tgz",
-      "integrity": "sha512-G3O+41xHbscpgL5nA0DUkbFVgaAz5rd57AMSIMew8p7C8SyFwZDyn08MoXHkTl9zcD0LmxsLFPxbqFY4YPbpPA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+      "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
       "dev": true,
       "requires": {
         "dargs": "4.1.0",
@@ -1424,9 +1432,9 @@
       }
     },
     "git-semver-tags": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.4.tgz",
-      "integrity": "sha512-Xe2Z74MwXZfAezuaO6e6cA4nsgeCiARPzaBp23gma325c/OXdt//PhrknptIaynNeUp2yWtmikV7k5RIicgGIQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
+      "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
       "dev": true,
       "requires": {
         "meow": "4.0.0",
@@ -1467,9 +1475,9 @@
       }
     },
     "globals": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-      "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+      "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
       "dev": true
     },
     "globby": {
@@ -1498,7 +1506,7 @@
         "is-redirect": "1.0.0",
         "is-retry-allowed": "1.1.0",
         "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
+        "lowercase-keys": "1.0.1",
         "safe-buffer": "5.1.1",
         "timed-out": "4.0.1",
         "unzip-response": "2.0.1",
@@ -1556,9 +1564,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
     },
     "iconv-lite": {
@@ -1613,11 +1621,11 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.0.0",
+        "ansi-escapes": "3.1.0",
         "chalk": "2.3.2",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
+        "external-editor": "2.2.0",
         "figures": "2.0.0",
         "lodash": "4.17.5",
         "mute-stream": "0.0.7",
@@ -1662,7 +1670,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.2"
+        "ci-info": "1.1.3"
       }
     },
     "is-extglob": {
@@ -1708,9 +1716,9 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -1806,7 +1814,7 @@
         "esprima": "2.7.3",
         "glob": "5.0.15",
         "handlebars": "4.0.11",
-        "js-yaml": "3.10.0",
+        "js-yaml": "3.11.0",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "once": "1.4.0",
@@ -1859,9 +1867,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
         "argparse": "1.0.10",
@@ -1869,9 +1877,9 @@
       }
     },
     "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -1933,9 +1941,9 @@
       }
     },
     "lerna": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-2.9.0.tgz",
-      "integrity": "sha512-8KvXqRsnkqkorOlE7tMnaDl8b43t8i6/ZyGthoyIzb7ikeH2XNrQOHuI1FWsuOtP2HY3vLp2zuMvM5Zuw3ulUA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-2.9.1.tgz",
+      "integrity": "sha512-jwfX9kljxv4Y4oqbCbNNXfKNH9uHB7jp+pcS6chIbGeTs+5mhKYL61gYIfm9yYDEsTgyrojPhrIeZkuzijr2iA==",
       "dev": true,
       "requires": {
         "async": "1.5.2",
@@ -1943,7 +1951,7 @@
         "cmd-shim": "2.0.2",
         "columnify": "1.5.4",
         "command-join": "2.0.0",
-        "conventional-changelog-cli": "1.3.16",
+        "conventional-changelog-cli": "1.3.21",
         "conventional-recommended-bump": "1.2.1",
         "dedent": "0.7.0",
         "execa": "0.8.0",
@@ -1954,7 +1962,7 @@
         "glob-parent": "3.1.0",
         "globby": "6.1.0",
         "graceful-fs": "4.1.11",
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "inquirer": "3.3.0",
         "is-ci": "1.1.0",
         "load-json-file": "4.0.0",
@@ -2204,15 +2212,15 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -2327,15 +2335,15 @@
       }
     },
     "modify-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
-      "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
     "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.0.tgz",
+      "integrity": "sha512-1muXCh8jb1N/gHRbn9VDUBr0GYb8A/aVcHlII9QSB68a50spqEVLIGN6KVmCOnSvJrUhC0edGgKU5ofnGXdYdg==",
       "dev": true
     },
     "ms": {
@@ -2371,7 +2379,7 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.5.0",
         "validate-npm-package-license": "3.0.3"
@@ -2549,7 +2557,7 @@
       "dev": true,
       "requires": {
         "error-ex": "1.3.1",
-        "json-parse-better-errors": "1.0.1"
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "path-dirname": {
@@ -2669,9 +2677,9 @@
       "dev": true
     },
     "rc": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
-      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -2793,9 +2801,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -2803,7 +2811,7 @@
         "isarray": "1.0.0",
         "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
+        "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       }
     },
@@ -2817,13 +2825,19 @@
         "strip-indent": "2.0.0"
       }
     },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
     "registry-auth-token": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.5",
+        "rc": "1.2.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -2833,7 +2847,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.5"
+        "rc": "1.2.6"
       }
     },
     "repeat-string": {
@@ -3078,9 +3092,9 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -3136,7 +3150,7 @@
         "byline": "5.0.0",
         "duplexer": "0.1.1",
         "minimist": "0.1.0",
-        "moment": "2.21.0",
+        "moment": "2.22.0",
         "through": "2.3.8"
       },
       "dependencies": {
@@ -3236,7 +3250,7 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "xtend": "4.0.1"
       }
     },

--- a/packages/react-redux-dynamic-reducer/package-lock.json
+++ b/packages/react-redux-dynamic-reducer/package-lock.json
@@ -3,19 +3,19 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
-			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+			"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.40"
+				"@babel/highlight": "7.0.0-beta.44"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
-			"integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.40",
+				"@babel/types": "7.0.0-beta.44",
 				"jsesc": "2.5.1",
 				"lodash": "4.17.5",
 				"source-map": "0.5.7",
@@ -30,27 +30,35 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
-			"integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+			"integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.40",
-				"@babel/template": "7.0.0-beta.40",
-				"@babel/types": "7.0.0-beta.40"
+				"@babel/helper-get-function-arity": "7.0.0-beta.44",
+				"@babel/template": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
-			"integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+			"integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.40"
+				"@babel/types": "7.0.0-beta.44"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+			"integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.44"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
-			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+			"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
 			"requires": {
 				"chalk": "2.3.2",
 				"esutils": "2.0.2",
@@ -86,43 +94,44 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
-			"integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+			"integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.40",
-				"@babel/types": "7.0.0-beta.40",
-				"babylon": "7.0.0-beta.40",
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
 				"lodash": "4.17.5"
 			},
 			"dependencies": {
 				"babylon": {
-					"version": "7.0.0-beta.40",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+					"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
 				}
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
-			"integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+			"integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.40",
-				"@babel/generator": "7.0.0-beta.40",
-				"@babel/helper-function-name": "7.0.0-beta.40",
-				"@babel/types": "7.0.0-beta.40",
-				"babylon": "7.0.0-beta.40",
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/generator": "7.0.0-beta.44",
+				"@babel/helper-function-name": "7.0.0-beta.44",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
 				"debug": "3.1.0",
-				"globals": "11.3.0",
-				"invariant": "2.2.3",
+				"globals": "11.4.0",
+				"invariant": "2.2.4",
 				"lodash": "4.17.5"
 			},
 			"dependencies": {
 				"babylon": {
-					"version": "7.0.0-beta.40",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+					"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -133,16 +142,16 @@
 					}
 				},
 				"globals": {
-					"version": "11.3.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-					"integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw=="
+					"version": "11.4.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+					"integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
 				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
-			"integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
 			"requires": {
 				"esutils": "2.0.2",
 				"lodash": "4.17.5",
@@ -158,21 +167,24 @@
 		},
 		"@sinonjs/formatio": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
 			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
 			"requires": {
 				"samsam": "1.3.0"
 			}
 		},
 		"@types/node": {
-			"version": "9.4.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-			"integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ=="
+			"version": "9.6.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.2.tgz",
+			"integrity": "sha512-UWkRY9X7RQHp5OhhRIIka58/gVVycL1zHZu0OTsT5LI86ABaMOSbUjAl+b0FeDhQcxclrkyft3kW5QWdMRs8wQ=="
 		},
 		"@types/react": {
-			"version": "16.0.40",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.40.tgz",
-			"integrity": "sha512-OZi2OPNI1DGwnC3Fgbr1CcYfOD6V0pbv+aehXdvuFE+L+sipWjividsasuqFW/G0CZrZ81Ao+9IzjvkRDWCE9Q=="
+			"version": "16.3.5",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.5.tgz",
+			"integrity": "sha512-hjdnnTrogK++yHd/eRLieGqITd0gZcd+NxYSbgdy6E/jQwq9QlXKIHleKGwgU0cYlL1KWNgCVfFpqmMUwVgniA==",
+			"requires": {
+				"csstype": "2.1.0"
+			}
 		},
 		"abab": {
 			"version": "1.0.4",
@@ -180,16 +192,16 @@
 			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
 		},
 		"acorn": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-			"integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-globals": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"requires": {
-				"acorn": "5.5.0"
+				"acorn": "5.5.3"
 			}
 		},
 		"acorn-jsx": {
@@ -224,9 +236,9 @@
 			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
 		},
 		"ansi-escapes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
@@ -282,7 +294,7 @@
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 			"requires": {
 				"define-properties": "1.1.2",
-				"es-abstract": "1.10.0"
+				"es-abstract": "1.11.0"
 			}
 		},
 		"array-union": {
@@ -365,7 +377,7 @@
 				"babel-register": "6.26.0",
 				"babel-runtime": "6.26.0",
 				"chokidar": "1.7.0",
-				"commander": "2.14.1",
+				"commander": "2.15.1",
 				"convert-source-map": "1.5.1",
 				"fs-readdir-recursive": "1.1.0",
 				"glob": "7.1.2",
@@ -415,21 +427,21 @@
 		},
 		"babel-eslint": {
 			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+			"resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
 			"integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.40",
-				"@babel/traverse": "7.0.0-beta.40",
-				"@babel/types": "7.0.0-beta.40",
-				"babylon": "7.0.0-beta.40",
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/traverse": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
 				"eslint-scope": "3.7.1",
 				"eslint-visitor-keys": "1.0.0"
 			},
 			"dependencies": {
 				"babylon": {
-					"version": "7.0.0-beta.40",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+					"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
 				}
 			}
 		},
@@ -953,7 +965,7 @@
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
 			"requires": {
 				"babel-runtime": "6.26.0",
-				"core-js": "2.5.3",
+				"core-js": "2.5.4",
 				"regenerator-runtime": "0.10.5"
 			},
 			"dependencies": {
@@ -997,7 +1009,7 @@
 				"babel-plugin-transform-exponentiation-operator": "6.24.1",
 				"babel-plugin-transform-regenerator": "6.26.0",
 				"browserslist": "2.11.3",
-				"invariant": "2.2.3",
+				"invariant": "2.2.4",
 				"semver": "5.5.0"
 			}
 		},
@@ -1041,7 +1053,7 @@
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-runtime": "6.26.0",
-				"core-js": "2.5.3",
+				"core-js": "2.5.4",
 				"home-or-tmp": "2.0.0",
 				"lodash": "4.17.5",
 				"mkdirp": "0.5.1",
@@ -1053,7 +1065,7 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "2.5.3",
+				"core-js": "2.5.4",
 				"regenerator-runtime": "0.11.1"
 			}
 		},
@@ -1081,7 +1093,7 @@
 				"babylon": "6.18.0",
 				"debug": "2.6.9",
 				"globals": "9.18.0",
-				"invariant": "2.2.3",
+				"invariant": "2.2.4",
 				"lodash": "4.17.5"
 			}
 		},
@@ -1169,9 +1181,14 @@
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
 			"requires": {
-				"caniuse-lite": "1.0.30000811",
-				"electron-to-chromium": "1.3.34"
+				"caniuse-lite": "1.0.30000823",
+				"electron-to-chromium": "1.3.42"
 			}
+		},
+		"buffer-from": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
 		},
 		"caller-path": {
 			"version": "0.1.0",
@@ -1187,9 +1204,9 @@
 			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000811",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000811.tgz",
-			"integrity": "sha512-IPqVics/FqTQqdgcUZLTIe4BBwK3ndvzrAP7NX2meM3kk/w3oGivwWXJ5yvh2PXhWsU6VIKOM4dZCYKgNFh5tg=="
+			"version": "1.0.30000823",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000823.tgz",
+			"integrity": "sha512-3rrhqUxwBgrwNlWVUEwIJfqdZNwLPX18eTo7MGXb3gueDpbOFW6w5OXyHscdBd6IJcu9wnKmKVd7nSl+r7fmgw=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -1316,9 +1333,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1326,19 +1343,15 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
+				"buffer-from": "1.0.0",
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.5",
+				"readable-stream": "2.3.6",
 				"typedarray": "0.0.6"
 			}
-		},
-		"content-type-parser": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
 		},
 		"convert-source-map": {
 			"version": "1.5.1",
@@ -1346,9 +1359,9 @@
 			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"core-js": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+			"integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1360,7 +1373,7 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"requires": {
-				"lru-cache": "4.1.1",
+				"lru-cache": "4.1.2",
 				"shebang-command": "1.2.0",
 				"which": "1.3.0"
 			}
@@ -1412,12 +1425,27 @@
 				"cssom": "0.3.2"
 			}
 		},
+		"csstype": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.1.0.tgz",
+			"integrity": "sha512-+7+cT9jVBoYMTcXH2Sc4pQlGhsDYuZPuSA+Ay9zuZm9UuSIFrkj2mZaYK5ty1hZSM0ZCuzVEKtZIF0cdGl84og=="
+		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
 				"assert-plus": "1.0.0"
+			}
+		},
+		"data-urls": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+			"requires": {
+				"abab": "1.0.4",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.0"
 			}
 		},
 		"debug": {
@@ -1457,7 +1485,7 @@
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.1",
 				"object-assign": "4.1.1",
 				"pify": "2.3.0",
 				"pinkie-promise": "2.0.1",
@@ -1596,9 +1624,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.34",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.34.tgz",
-			"integrity": "sha1-2TSY9AORuwwWpgPYJBuZUUBBV+0="
+			"version": "1.3.42",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
+			"integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk="
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -1647,7 +1675,7 @@
 				"object.values": "1.0.4",
 				"prop-types": "15.6.1",
 				"react-reconciler": "0.7.0",
-				"react-test-renderer": "16.2.0"
+				"react-test-renderer": "16.3.1"
 			}
 		},
 		"enzyme-adapter-utils": {
@@ -1661,9 +1689,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.1",
@@ -1713,31 +1741,31 @@
 			}
 		},
 		"eslint": {
-			"version": "4.18.2",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
-			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+			"version": "4.19.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"requires": {
 				"ajv": "5.5.2",
 				"babel-code-frame": "6.26.0",
 				"chalk": "2.3.2",
-				"concat-stream": "1.6.1",
+				"concat-stream": "1.6.2",
 				"cross-spawn": "5.1.0",
 				"debug": "3.1.0",
 				"doctrine": "2.1.0",
 				"eslint-scope": "3.7.1",
 				"eslint-visitor-keys": "1.0.0",
-				"espree": "3.5.3",
-				"esquery": "1.0.0",
+				"espree": "3.5.4",
+				"esquery": "1.0.1",
 				"esutils": "2.0.2",
 				"file-entry-cache": "2.0.0",
 				"functional-red-black-tree": "1.0.1",
 				"glob": "7.1.2",
-				"globals": "11.3.0",
+				"globals": "11.4.0",
 				"ignore": "3.3.7",
 				"imurmurhash": "0.1.4",
 				"inquirer": "3.3.0",
 				"is-resolvable": "1.1.0",
-				"js-yaml": "3.10.0",
+				"js-yaml": "3.11.0",
 				"json-stable-stringify-without-jsonify": "1.0.1",
 				"levn": "0.3.0",
 				"lodash": "4.17.5",
@@ -1748,6 +1776,7 @@
 				"path-is-inside": "1.0.2",
 				"pluralize": "7.0.0",
 				"progress": "2.0.0",
+				"regexpp": "1.1.0",
 				"require-uncached": "1.0.3",
 				"semver": "5.5.0",
 				"strip-ansi": "4.0.0",
@@ -1788,9 +1817,9 @@
 					}
 				},
 				"globals": {
-					"version": "11.3.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-					"integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw=="
+					"version": "11.4.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+					"integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
@@ -1836,11 +1865,11 @@
 			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
 		},
 		"espree": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
-			"integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"requires": {
-				"acorn": "5.5.0",
+				"acorn": "5.5.3",
 				"acorn-jsx": "3.0.1"
 			}
 		},
@@ -1850,9 +1879,9 @@
 			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"esquery": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1899,9 +1928,9 @@
 			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 		},
 		"external-editor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"requires": {
 				"chardet": "0.4.2",
 				"iconv-lite": "0.4.19",
@@ -2056,7 +2085,7 @@
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
-				"nan": "2.9.2",
+				"nan": "2.10.0",
 				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
@@ -3029,7 +3058,7 @@
 				"domutils": "1.5.1",
 				"entities": "1.1.1",
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.5"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"http-signature": {
@@ -3039,7 +3068,7 @@
 			"requires": {
 				"assert-plus": "1.0.0",
 				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
+				"sshpk": "1.14.1"
 			}
 		},
 		"iconv-lite": {
@@ -3076,11 +3105,11 @@
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"requires": {
-				"ansi-escapes": "3.0.0",
+				"ansi-escapes": "3.1.0",
 				"chalk": "2.3.2",
 				"cli-cursor": "2.1.0",
 				"cli-width": "2.2.0",
-				"external-editor": "2.1.0",
+				"external-editor": "2.2.0",
 				"figures": "2.0.0",
 				"lodash": "4.17.5",
 				"mute-stream": "0.0.7",
@@ -3134,9 +3163,9 @@
 			}
 		},
 		"invariant": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -3237,9 +3266,9 @@
 			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
 		},
 		"is-path-in-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"requires": {
 				"is-path-inside": "1.0.1"
 			}
@@ -3332,7 +3361,7 @@
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
 				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.3"
+				"whatwg-fetch": "2.0.4"
 			}
 		},
 		"isstream": {
@@ -3346,9 +3375,9 @@
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.0"
@@ -3361,26 +3390,25 @@
 			"optional": true
 		},
 		"jsdom": {
-			"version": "11.6.2",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
-			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+			"version": "11.7.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.7.0.tgz",
+			"integrity": "sha512-9NzSc4Iz4gN9p4uoPbBUzro21QdgL32swaWIaWS8eEVQ2I69fRJAy/MKyvlEIk0V7HtKgfMbbOKyTZUrzR2Hsw==",
 			"requires": {
 				"abab": "1.0.4",
-				"acorn": "5.5.0",
+				"acorn": "5.5.3",
 				"acorn-globals": "4.1.0",
 				"array-equal": "1.0.0",
-				"browser-process-hrtime": "0.1.2",
-				"content-type-parser": "1.0.2",
 				"cssom": "0.3.2",
 				"cssstyle": "0.2.37",
+				"data-urls": "1.0.0",
 				"domexception": "1.0.1",
 				"escodegen": "1.9.1",
 				"html-encoding-sniffer": "1.0.2",
 				"left-pad": "1.2.0",
-				"nwmatcher": "1.4.3",
+				"nwmatcher": "1.4.4",
 				"parse5": "4.0.0",
 				"pn": "1.1.0",
-				"request": "2.83.0",
+				"request": "2.85.0",
 				"request-promise-native": "1.0.5",
 				"sax": "1.2.4",
 				"symbol-tree": "3.2.2",
@@ -3388,6 +3416,7 @@
 				"w3c-hr-time": "1.0.1",
 				"webidl-conversions": "4.0.2",
 				"whatwg-encoding": "1.0.3",
+				"whatwg-mimetype": "2.1.0",
 				"whatwg-url": "6.4.0",
 				"ws": "4.1.0",
 				"xml-name-validator": "3.0.0"
@@ -3487,9 +3516,9 @@
 			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
 		},
 		"lodash-es": {
-			"version": "4.17.5",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+			"version": "4.17.8",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.8.tgz",
+			"integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA=="
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
@@ -3525,9 +3554,9 @@
 			}
 		},
 		"lru-cache": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -3649,9 +3678,9 @@
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
-			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
 			"optional": true
 		},
 		"natural-compare": {
@@ -3660,9 +3689,9 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"nearley": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.1.tgz",
-			"integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.13.0.tgz",
+			"integrity": "sha512-ioYYogSaZhFlCpRizQgY3UT3G1qFXmHGY/5ozoFE3dMfiCRAeJfh+IPE3/eh9gCZvqLhPCWb4bLt7Bqzo+1mLQ==",
 			"requires": {
 				"nomnom": "1.6.2",
 				"railroad-diagrams": "1.0.0",
@@ -3671,9 +3700,9 @@
 			}
 		},
 		"nise": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
-			"integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
+			"integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"just-extend": "1.1.27",
@@ -3722,14 +3751,14 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwmatcher": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
 		},
 		"nyc": {
-			"version": "11.4.1",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
-			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
+			"integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
 			"requires": {
 				"archy": "1.0.0",
 				"arrify": "1.0.1",
@@ -3741,23 +3770,23 @@
 				"find-up": "2.1.0",
 				"foreground-child": "1.5.6",
 				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.1.1",
+				"istanbul-lib-coverage": "1.2.0",
 				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.9.1",
-				"istanbul-lib-report": "1.1.2",
-				"istanbul-lib-source-maps": "1.2.2",
-				"istanbul-reports": "1.1.3",
+				"istanbul-lib-instrument": "1.10.1",
+				"istanbul-lib-report": "1.1.3",
+				"istanbul-lib-source-maps": "1.2.3",
+				"istanbul-reports": "1.3.0",
 				"md5-hex": "1.3.0",
-				"merge-source-map": "1.0.4",
+				"merge-source-map": "1.1.0",
 				"micromatch": "2.3.11",
 				"mkdirp": "0.5.1",
 				"resolve-from": "2.0.0",
 				"rimraf": "2.6.2",
 				"signal-exit": "3.0.2",
 				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.1.1",
-				"yargs": "10.0.3",
-				"yargs-parser": "8.0.0"
+				"test-exclude": "4.2.1",
+				"yargs": "11.1.0",
+				"yargs-parser": "8.1.0"
 			},
 			"dependencies": {
 				"align-text": {
@@ -3803,6 +3832,10 @@
 					"version": "1.1.0",
 					"bundled": true
 				},
+				"arr-union": {
+					"version": "3.1.0",
+					"bundled": true
+				},
 				"array-unique": {
 					"version": "0.2.1",
 					"bundled": true
@@ -3811,8 +3844,16 @@
 					"version": "1.0.1",
 					"bundled": true
 				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"bundled": true
+				},
 				"async": {
 					"version": "1.5.2",
+					"bundled": true
+				},
+				"atob": {
+					"version": "2.0.3",
 					"bundled": true
 				},
 				"babel-code-frame": {
@@ -3825,7 +3866,7 @@
 					}
 				},
 				"babel-generator": {
-					"version": "6.26.0",
+					"version": "6.26.1",
 					"bundled": true,
 					"requires": {
 						"babel-messages": "6.23.0",
@@ -3833,7 +3874,7 @@
 						"babel-types": "6.26.0",
 						"detect-indent": "4.0.0",
 						"jsesc": "1.3.0",
-						"lodash": "4.17.4",
+						"lodash": "4.17.5",
 						"source-map": "0.5.7",
 						"trim-right": "1.0.1"
 					}
@@ -3861,7 +3902,7 @@
 						"babel-traverse": "6.26.0",
 						"babel-types": "6.26.0",
 						"babylon": "6.18.0",
-						"lodash": "4.17.4"
+						"lodash": "4.17.5"
 					}
 				},
 				"babel-traverse": {
@@ -3875,8 +3916,8 @@
 						"babylon": "6.18.0",
 						"debug": "2.6.9",
 						"globals": "9.18.0",
-						"invariant": "2.2.2",
-						"lodash": "4.17.4"
+						"invariant": "2.2.3",
+						"lodash": "4.17.5"
 					}
 				},
 				"babel-types": {
@@ -3885,7 +3926,7 @@
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"esutils": "2.0.2",
-						"lodash": "4.17.4",
+						"lodash": "4.17.5",
 						"to-fast-properties": "1.0.3"
 					}
 				},
@@ -3897,8 +3938,34 @@
 					"version": "1.0.0",
 					"bundled": true
 				},
+				"base": {
+					"version": "0.11.2",
+					"bundled": true,
+					"requires": {
+						"cache-base": "1.0.1",
+						"class-utils": "0.3.6",
+						"component-emitter": "1.2.1",
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"mixin-deep": "1.3.1",
+						"pascalcase": "0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
 				"brace-expansion": {
-					"version": "1.1.8",
+					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
 						"balanced-match": "1.0.0",
@@ -3917,6 +3984,27 @@
 				"builtin-modules": {
 					"version": "1.1.1",
 					"bundled": true
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"collection-visit": "1.0.0",
+						"component-emitter": "1.2.1",
+						"get-value": "2.0.6",
+						"has-value": "1.0.0",
+						"isobject": "3.0.1",
+						"set-value": "2.0.0",
+						"to-object-path": "0.3.0",
+						"union-value": "1.0.0",
+						"unset-value": "1.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
 				},
 				"caching-transform": {
 					"version": "1.0.1",
@@ -3952,6 +4040,74 @@
 						"supports-color": "2.0.0"
 					}
 				},
+				"class-utils": {
+					"version": "0.3.6",
+					"bundled": true,
+					"requires": {
+						"arr-union": "3.1.0",
+						"define-property": "0.2.5",
+						"isobject": "3.0.1",
+						"static-extend": "0.1.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
@@ -3973,8 +4129,20 @@
 					"version": "1.1.0",
 					"bundled": true
 				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"map-visit": "1.0.0",
+						"object-visit": "1.0.1"
+					}
+				},
 				"commondir": {
 					"version": "1.0.1",
+					"bundled": true
+				},
+				"component-emitter": {
+					"version": "1.2.1",
 					"bundled": true
 				},
 				"concat-map": {
@@ -3985,6 +4153,10 @@
 					"version": "1.5.1",
 					"bundled": true
 				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"bundled": true
+				},
 				"core-js": {
 					"version": "2.5.3",
 					"bundled": true
@@ -3993,7 +4165,7 @@
 					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "4.1.1",
+						"lru-cache": "4.1.2",
 						"which": "1.3.0"
 					}
 				},
@@ -4012,11 +4184,29 @@
 					"version": "1.2.0",
 					"bundled": true
 				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true
+				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
 						"strip-bom": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"is-descriptor": "1.0.2",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
 					}
 				},
 				"detect-indent": {
@@ -4058,7 +4248,7 @@
 							"version": "5.1.0",
 							"bundled": true,
 							"requires": {
-								"lru-cache": "4.1.1",
+								"lru-cache": "4.1.2",
 								"shebang-command": "1.2.0",
 								"which": "1.3.0"
 							}
@@ -4077,6 +4267,23 @@
 					"bundled": true,
 					"requires": {
 						"fill-range": "2.2.3"
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
 					}
 				},
 				"extglob": {
@@ -4136,6 +4343,13 @@
 						"signal-exit": "3.0.2"
 					}
 				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"bundled": true,
+					"requires": {
+						"map-cache": "0.2.2"
+					}
+				},
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true
@@ -4146,6 +4360,10 @@
 				},
 				"get-stream": {
 					"version": "3.0.0",
+					"bundled": true
+				},
+				"get-value": {
+					"version": "2.0.6",
 					"bundled": true
 				},
 				"glob": {
@@ -4213,8 +4431,56 @@
 					"version": "1.0.0",
 					"bundled": true
 				},
+				"has-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"get-value": "2.0.6",
+						"has-values": "1.0.0",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
 				"hosted-git-info": {
-					"version": "2.5.0",
+					"version": "2.6.0",
 					"bundled": true
 				},
 				"imurmurhash": {
@@ -4234,7 +4500,7 @@
 					"bundled": true
 				},
 				"invariant": {
-					"version": "2.2.2",
+					"version": "2.2.3",
 					"bundled": true,
 					"requires": {
 						"loose-envify": "1.3.1"
@@ -4243,6 +4509,19 @@
 				"invert-kv": {
 					"version": "1.0.0",
 					"bundled": true
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
@@ -4257,6 +4536,34 @@
 					"bundled": true,
 					"requires": {
 						"builtin-modules": "1.1.1"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
 					}
 				},
 				"is-dotfile": {
@@ -4286,11 +4593,8 @@
 					}
 				},
 				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
+					"version": "2.0.0",
+					"bundled": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
@@ -4304,6 +4608,32 @@
 					"bundled": true,
 					"requires": {
 						"kind-of": "3.2.2"
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
 					}
 				},
 				"is-posix-bracket": {
@@ -4322,6 +4652,10 @@
 					"version": "0.2.1",
 					"bundled": true
 				},
+				"is-windows": {
+					"version": "1.0.2",
+					"bundled": true
+				},
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true
@@ -4338,7 +4672,7 @@
 					}
 				},
 				"istanbul-lib-coverage": {
-					"version": "1.1.1",
+					"version": "1.2.0",
 					"bundled": true
 				},
 				"istanbul-lib-hook": {
@@ -4349,23 +4683,23 @@
 					}
 				},
 				"istanbul-lib-instrument": {
-					"version": "1.9.1",
+					"version": "1.10.1",
 					"bundled": true,
 					"requires": {
-						"babel-generator": "6.26.0",
+						"babel-generator": "6.26.1",
 						"babel-template": "6.26.0",
 						"babel-traverse": "6.26.0",
 						"babel-types": "6.26.0",
 						"babylon": "6.18.0",
-						"istanbul-lib-coverage": "1.1.1",
-						"semver": "5.4.1"
+						"istanbul-lib-coverage": "1.2.0",
+						"semver": "5.5.0"
 					}
 				},
 				"istanbul-lib-report": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.1.1",
+						"istanbul-lib-coverage": "1.2.0",
 						"mkdirp": "0.5.1",
 						"path-parse": "1.0.5",
 						"supports-color": "3.2.3"
@@ -4381,11 +4715,11 @@
 					}
 				},
 				"istanbul-lib-source-maps": {
-					"version": "1.2.2",
+					"version": "1.2.3",
 					"bundled": true,
 					"requires": {
 						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.1.1",
+						"istanbul-lib-coverage": "1.2.0",
 						"mkdirp": "0.5.1",
 						"rimraf": "2.6.2",
 						"source-map": "0.5.7"
@@ -4401,7 +4735,7 @@
 					}
 				},
 				"istanbul-reports": {
-					"version": "1.1.3",
+					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
 						"handlebars": "4.0.11"
@@ -4460,7 +4794,7 @@
 					}
 				},
 				"lodash": {
-					"version": "4.17.4",
+					"version": "4.17.5",
 					"bundled": true
 				},
 				"longest": {
@@ -4475,11 +4809,22 @@
 					}
 				},
 				"lru-cache": {
-					"version": "4.1.1",
+					"version": "4.1.2",
 					"bundled": true,
 					"requires": {
 						"pseudomap": "1.0.2",
 						"yallist": "2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"bundled": true
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"object-visit": "1.0.1"
 					}
 				},
 				"md5-hex": {
@@ -4497,14 +4842,20 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"mimic-fn": "1.1.0"
+						"mimic-fn": "1.2.0"
 					}
 				},
 				"merge-source-map": {
-					"version": "1.0.4",
+					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"source-map": "0.5.7"
+						"source-map": "0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true
+						}
 					}
 				},
 				"micromatch": {
@@ -4527,19 +4878,36 @@
 					}
 				},
 				"mimic-fn": {
-					"version": "1.1.0",
+					"version": "1.2.0",
 					"bundled": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"for-in": "1.0.2",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
+					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
@@ -4552,14 +4920,46 @@
 					"version": "2.0.0",
 					"bundled": true
 				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"fragment-cache": "0.2.1",
+						"is-odd": "2.0.0",
+						"is-windows": "1.0.2",
+						"kind-of": "6.0.2",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "2.5.0",
+						"hosted-git-info": "2.6.0",
 						"is-builtin-module": "1.0.0",
-						"semver": "5.4.1",
-						"validate-npm-package-license": "3.0.1"
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.3"
 					}
 				},
 				"normalize-path": {
@@ -4584,12 +4984,85 @@
 					"version": "4.1.1",
 					"bundled": true
 				},
+				"object-copy": {
+					"version": "0.1.0",
+					"bundled": true,
+					"requires": {
+						"copy-descriptor": "0.1.1",
+						"define-property": "0.2.5",
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "5.1.0",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
 				"object.omit": {
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
 						"for-own": "0.1.5",
 						"is-extendable": "0.1.1"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
 					}
 				},
 				"once": {
@@ -4625,15 +5098,22 @@
 					"bundled": true
 				},
 				"p-limit": {
-					"version": "1.1.0",
-					"bundled": true
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"p-try": "1.0.0"
+					}
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-limit": "1.1.0"
+						"p-limit": "1.2.0"
 					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"bundled": true
 				},
 				"parse-glob": {
 					"version": "3.0.4",
@@ -4651,6 +5131,10 @@
 					"requires": {
 						"error-ex": "1.3.1"
 					}
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"bundled": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
@@ -4711,6 +5195,10 @@
 							}
 						}
 					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"bundled": true
 				},
 				"preserve": {
 					"version": "0.2.0",
@@ -4791,6 +5279,14 @@
 						"is-equal-shallow": "0.1.3"
 					}
 				},
+				"regex-not": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "3.0.2",
+						"safe-regex": "1.1.0"
+					}
+				},
 				"remove-trailing-separator": {
 					"version": "1.1.0",
 					"bundled": true
@@ -4822,6 +5318,14 @@
 					"version": "2.0.0",
 					"bundled": true
 				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"ret": {
+					"version": "0.1.15",
+					"bundled": true
+				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
@@ -4837,13 +5341,39 @@
 						"glob": "7.1.2"
 					}
 				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"ret": "0.1.15"
+					}
+				},
 				"semver": {
-					"version": "5.4.1",
+					"version": "5.5.0",
 					"bundled": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"split-string": "3.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
 				},
 				"shebang-command": {
 					"version": "1.2.0",
@@ -4864,8 +5394,127 @@
 					"version": "1.1.6",
 					"bundled": true
 				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"bundled": true,
+					"requires": {
+						"base": "0.11.2",
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"map-cache": "0.2.2",
+						"source-map": "0.5.7",
+						"source-map-resolve": "0.5.1",
+						"use": "3.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"snapdragon-util": "3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
 				"source-map": {
 					"version": "0.5.7",
+					"bundled": true
+				},
+				"source-map-resolve": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"atob": "2.0.3",
+						"decode-uri-component": "0.2.0",
+						"resolve-url": "0.2.1",
+						"source-map-url": "0.4.0",
+						"urix": "0.1.0"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
 					"bundled": true
 				},
 				"spawn-wrap": {
@@ -4881,19 +5530,97 @@
 					}
 				},
 				"spdx-correct": {
-					"version": "1.0.2",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-license-ids": "1.2.2"
+						"spdx-expression-parse": "3.0.0",
+						"spdx-license-ids": "3.0.0"
 					}
 				},
-				"spdx-expression-parse": {
-					"version": "1.0.4",
+				"spdx-exceptions": {
+					"version": "2.1.0",
 					"bundled": true
 				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-exceptions": "2.1.0",
+						"spdx-license-ids": "3.0.0"
+					}
+				},
 				"spdx-license-ids": {
-					"version": "1.2.2",
+					"version": "3.0.0",
 					"bundled": true
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "3.0.2"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "0.2.5",
+						"object-copy": "0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
 				},
 				"string-width": {
 					"version": "2.1.1",
@@ -4905,10 +5632,6 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
 							"bundled": true
 						},
 						"strip-ansi": {
@@ -4943,19 +5666,263 @@
 					"bundled": true
 				},
 				"test-exclude": {
-					"version": "4.1.1",
+					"version": "4.2.1",
 					"bundled": true,
 					"requires": {
 						"arrify": "1.0.1",
-						"micromatch": "2.3.11",
+						"micromatch": "3.1.9",
 						"object-assign": "4.1.1",
 						"read-pkg-up": "1.0.1",
 						"require-main-filename": "1.0.1"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"bundled": true
+						},
+						"braces": {
+							"version": "2.3.1",
+							"bundled": true,
+							"requires": {
+								"arr-flatten": "1.1.0",
+								"array-unique": "0.3.2",
+								"define-property": "1.0.0",
+								"extend-shallow": "2.0.1",
+								"fill-range": "4.0.0",
+								"isobject": "3.0.1",
+								"kind-of": "6.0.2",
+								"repeat-element": "1.1.2",
+								"snapdragon": "0.8.2",
+								"snapdragon-node": "2.1.1",
+								"split-string": "3.1.0",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "1.0.2"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"expand-brackets": {
+							"version": "2.1.4",
+							"bundled": true,
+							"requires": {
+								"debug": "2.6.9",
+								"define-property": "0.2.5",
+								"extend-shallow": "2.0.1",
+								"posix-character-classes": "0.1.1",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "0.2.5",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "0.1.6"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								},
+								"is-descriptor": {
+									"version": "0.1.6",
+									"bundled": true,
+									"requires": {
+										"is-accessor-descriptor": "0.1.6",
+										"is-data-descriptor": "0.1.4",
+										"kind-of": "5.1.0"
+									}
+								},
+								"kind-of": {
+									"version": "5.1.0",
+									"bundled": true
+								}
+							}
+						},
+						"extglob": {
+							"version": "2.0.4",
+							"bundled": true,
+							"requires": {
+								"array-unique": "0.3.2",
+								"define-property": "1.0.0",
+								"expand-brackets": "2.1.4",
+								"extend-shallow": "2.0.1",
+								"fragment-cache": "0.2.1",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "1.0.2"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"fill-range": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "2.0.1",
+								"is-number": "3.0.0",
+								"repeat-string": "1.6.1",
+								"to-regex-range": "2.1.1"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						},
+						"micromatch": {
+							"version": "3.1.9",
+							"bundled": true,
+							"requires": {
+								"arr-diff": "4.0.0",
+								"array-unique": "0.3.2",
+								"braces": "2.3.1",
+								"define-property": "2.0.2",
+								"extend-shallow": "3.0.2",
+								"extglob": "2.0.4",
+								"fragment-cache": "0.2.1",
+								"kind-of": "6.0.2",
+								"nanomatch": "1.2.9",
+								"object.pick": "1.3.0",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							}
+						}
 					}
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
 					"bundled": true
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"regex-not": "1.0.2",
+						"safe-regex": "1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						}
+					}
 				},
 				"trim-right": {
 					"version": "1.0.1",
@@ -4989,12 +5956,94 @@
 					"bundled": true,
 					"optional": true
 				},
-				"validate-npm-package-license": {
-					"version": "3.0.1",
+				"union-value": {
+					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-correct": "1.0.2",
-						"spdx-expression-parse": "1.0.4"
+						"arr-union": "3.1.0",
+						"get-value": "2.0.6",
+						"is-extendable": "0.1.1",
+						"set-value": "0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "2.0.1",
+								"is-extendable": "0.1.1",
+								"is-plain-object": "2.0.4",
+								"to-object-path": "0.3.0"
+							}
+						}
+					}
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"has-value": "0.3.1",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"bundled": true,
+							"requires": {
+								"get-value": "2.0.6",
+								"has-values": "0.1.4",
+								"isobject": "2.1.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"bundled": true
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"bundled": true
+				},
+				"use": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "3.0.0",
+						"spdx-expression-parse": "3.0.0"
 					}
 				},
 				"which": {
@@ -5025,6 +6074,13 @@
 						"strip-ansi": "3.0.1"
 					},
 					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "1.0.1"
+							}
+						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
@@ -5058,10 +6114,10 @@
 					"bundled": true
 				},
 				"yargs": {
-					"version": "10.0.3",
+					"version": "11.1.0",
 					"bundled": true,
 					"requires": {
-						"cliui": "3.2.0",
+						"cliui": "4.0.0",
 						"decamelize": "1.2.0",
 						"find-up": "2.1.0",
 						"get-caller-file": "1.0.2",
@@ -5072,33 +6128,44 @@
 						"string-width": "2.1.1",
 						"which-module": "2.0.0",
 						"y18n": "3.2.1",
-						"yargs-parser": "8.0.0"
+						"yargs-parser": "9.0.2"
 					},
 					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						},
 						"cliui": {
-							"version": "3.2.0",
+							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"string-width": "1.0.2",
-								"strip-ansi": "3.0.1",
+								"string-width": "2.1.1",
+								"strip-ansi": "4.0.0",
 								"wrap-ansi": "2.1.0"
-							},
-							"dependencies": {
-								"string-width": {
-									"version": "1.0.2",
-									"bundled": true,
-									"requires": {
-										"code-point-at": "1.1.0",
-										"is-fullwidth-code-point": "1.0.0",
-										"strip-ansi": "3.0.1"
-									}
-								}
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						},
+						"yargs-parser": {
+							"version": "9.0.2",
+							"bundled": true,
+							"requires": {
+								"camelcase": "4.1.0"
 							}
 						}
 					}
 				},
 				"yargs-parser": {
-					"version": "8.0.0",
+					"version": "8.1.0",
 					"bundled": true,
 					"requires": {
 						"camelcase": "4.1.0"
@@ -5154,7 +6221,7 @@
 			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
 			"requires": {
 				"define-properties": "1.1.2",
-				"es-abstract": "1.10.0",
+				"es-abstract": "1.11.0",
 				"function-bind": "1.1.1",
 				"has": "1.0.1"
 			}
@@ -5175,7 +6242,7 @@
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
 			"requires": {
 				"define-properties": "1.1.2",
-				"es-abstract": "1.10.0",
+				"es-abstract": "1.11.0",
 				"function-bind": "1.1.1",
 				"has": "1.0.1"
 			}
@@ -5246,7 +6313,7 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
 			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
 			"requires": {
-				"@types/node": "9.4.6"
+				"@types/node": "9.6.2"
 			}
 		},
 		"path-is-absolute": {
@@ -5362,9 +6429,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+			"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
 		},
 		"qs": {
 			"version": "6.5.1",
@@ -5435,9 +6502,9 @@
 			}
 		},
 		"react": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-			"integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.3.1.tgz",
+			"integrity": "sha512-NbkxN9jsZ6+G+ICsLdC7/wUD26uNbvKU/RAxEWgc9kcdKvROt+5d5j2cNQm5PSFTQ4WNGsR3pa4qL2Q0/WSy1w==",
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -5446,15 +6513,20 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-			"integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.1.tgz",
+			"integrity": "sha512-2Infg89vzahq8nfVi1GkjPqq0vrBvf0f3T0+dTtyjq4f6HKOqKixAK25Vr593O3QTx4kw/vmUtAJwerlevNWOA==",
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
 				"object-assign": "4.1.1",
 				"prop-types": "15.6.1"
 			}
+		},
+		"react-is": {
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.3.1.tgz",
+			"integrity": "sha512-3XpazGqS5DEOLiuR6JQ2Sg6URq/33d1BHJVaUvtMz579KRhd2D0pqabNEe5czv785yzKBPZimOf0UNIXa3jw1A=="
 		},
 		"react-reconciler": {
 			"version": "0.7.0",
@@ -5473,45 +6545,47 @@
 			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
 			"requires": {
 				"hoist-non-react-statics": "2.5.0",
-				"invariant": "2.2.3",
+				"invariant": "2.2.4",
 				"lodash": "4.17.5",
-				"lodash-es": "4.17.5",
+				"lodash-es": "4.17.8",
 				"loose-envify": "1.3.1",
 				"prop-types": "15.6.1"
 			}
 		},
 		"react-redux-subspace": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/react-redux-subspace/-/react-redux-subspace-2.3.1.tgz",
-			"integrity": "sha512-2+aUiHUTSpw3QoheVZTDUl3xXJZtEQwfnjl8bJp6EzOzE17uLgDKr8SlKs8VYIK4Xy3yJwiF85wvSEM7tKUSZw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/react-redux-subspace/-/react-redux-subspace-2.4.0.tgz",
+			"integrity": "sha512-9fhCKE9hdaGwxYMcjnqcn1ZiMk3O4cvqadp1R70tGvMI89eit14fenu+64Iw1ye8Fx5BaWieZrq1vo42XgSn8A==",
 			"requires": {
+				"@types/react": "16.3.5",
 				"hoist-non-react-statics": "2.5.0",
 				"prop-types": "15.6.1",
 				"recompose": "0.26.0",
-				"redux-subspace": "2.3.1"
+				"redux-subspace": "2.4.0"
 			}
 		},
 		"react-test-renderer": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.2.0.tgz",
-			"integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.3.1.tgz",
+			"integrity": "sha512-emEcIPUowMjT5EQ+rrb0FAwVCzuJ+LKDweoYDh073v2/jHxrBDPUk8nzI5dofG3R+140+Bb9TMcT2Ez5OP6pQw==",
 			"requires": {
 				"fbjs": "0.8.16",
 				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
+				"prop-types": "15.6.1",
+				"react-is": "16.3.1"
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
 				"isarray": "1.0.0",
 				"process-nextick-args": "2.0.0",
 				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
+				"string_decoder": "1.1.1",
 				"util-deprecate": "1.0.2"
 			}
 		},
@@ -5523,7 +6597,7 @@
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"minimatch": "3.0.4",
-				"readable-stream": "2.3.5",
+				"readable-stream": "2.3.6",
 				"set-immediate-shim": "1.0.1"
 			}
 		},
@@ -5544,7 +6618,7 @@
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
 			"requires": {
 				"lodash": "4.17.5",
-				"lodash-es": "4.17.5",
+				"lodash-es": "4.17.8",
 				"loose-envify": "1.3.1",
 				"symbol-observable": "1.2.0"
 			}
@@ -5558,9 +6632,9 @@
 			}
 		},
 		"redux-subspace": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/redux-subspace/-/redux-subspace-2.3.1.tgz",
-			"integrity": "sha512-TvIocGp75L4h0QxijSWPSzZmyHbivXj2/KFAKYMdbIEAoKb3FOt/pMwXP3/mQd8zJJf/JDgnTvIaGPGvc0opaQ=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/redux-subspace/-/redux-subspace-2.4.0.tgz",
+			"integrity": "sha512-ZksMUO7LpfwDV2mNCnnWkVkkc9lznW9I2/u7zQmzlJPkd5f2ypvM7BYR0p6p+o/47YJDjqiHAr4/w5z914UJcw=="
 		},
 		"regenerate": {
 			"version": "1.3.3",
@@ -5590,6 +6664,11 @@
 			"requires": {
 				"is-equal-shallow": "0.1.3"
 			}
+		},
+		"regexpp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
 		},
 		"regexpu-core": {
 			"version": "2.0.0",
@@ -5646,9 +6725,9 @@
 			}
 		},
 		"request": {
-			"version": "2.83.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"version": "2.85.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+			"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
 			"requires": {
 				"aws-sign2": "0.7.0",
 				"aws4": "1.6.0",
@@ -5734,7 +6813,7 @@
 			"integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
 			"requires": {
 				"lodash.flattendeep": "4.4.0",
-				"nearley": "2.11.1"
+				"nearley": "2.13.0"
 			}
 		},
 		"run-async": {
@@ -5808,15 +6887,15 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"sinon": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
-			"integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+			"integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"diff": "3.3.1",
 				"lodash.get": "4.4.2",
 				"lolex": "2.3.2",
-				"nise": "1.3.0",
+				"nise": "1.3.2",
 				"supports-color": "5.3.0",
 				"type-detect": "4.0.8"
 			},
@@ -5876,9 +6955,9 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
 			"requires": {
 				"asn1": "0.2.3",
 				"assert-plus": "1.0.0",
@@ -5920,9 +6999,9 @@
 			}
 		},
 		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -6035,6 +7114,13 @@
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"requires": {
 				"punycode": "1.4.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				}
 			}
 		},
 		"tr46": {
@@ -6043,13 +7129,6 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"requires": {
 				"punycode": "2.1.0"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-				}
 			}
 		},
 		"trim-right": {
@@ -6090,9 +7169,9 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"typescript": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+			"integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg=="
 		},
 		"typescript-definition-tester": {
 			"version": "0.0.5",
@@ -6176,9 +7255,14 @@
 			}
 		},
 		"whatwg-fetch": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+		},
+		"whatwg-mimetype": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+			"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew=="
 		},
 		"whatwg-url": {
 			"version": "6.4.0",

--- a/packages/redux-dynamic-reducer/package-lock.json
+++ b/packages/redux-dynamic-reducer/package-lock.json
@@ -3,19 +3,19 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
-			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+			"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.40"
+				"@babel/highlight": "7.0.0-beta.44"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
-			"integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.40",
+				"@babel/types": "7.0.0-beta.44",
 				"jsesc": "2.5.1",
 				"lodash": "4.17.5",
 				"source-map": "0.5.7",
@@ -30,27 +30,35 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
-			"integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+			"integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.40",
-				"@babel/template": "7.0.0-beta.40",
-				"@babel/types": "7.0.0-beta.40"
+				"@babel/helper-get-function-arity": "7.0.0-beta.44",
+				"@babel/template": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
-			"integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+			"integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
 			"requires": {
-				"@babel/types": "7.0.0-beta.40"
+				"@babel/types": "7.0.0-beta.44"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+			"integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.44"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
-			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+			"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
 			"requires": {
 				"chalk": "2.3.2",
 				"esutils": "2.0.2",
@@ -86,43 +94,44 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
-			"integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+			"integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.40",
-				"@babel/types": "7.0.0-beta.40",
-				"babylon": "7.0.0-beta.40",
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
 				"lodash": "4.17.5"
 			},
 			"dependencies": {
 				"babylon": {
-					"version": "7.0.0-beta.40",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+					"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
 				}
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
-			"integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+			"integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.40",
-				"@babel/generator": "7.0.0-beta.40",
-				"@babel/helper-function-name": "7.0.0-beta.40",
-				"@babel/types": "7.0.0-beta.40",
-				"babylon": "7.0.0-beta.40",
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/generator": "7.0.0-beta.44",
+				"@babel/helper-function-name": "7.0.0-beta.44",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
 				"debug": "3.1.0",
-				"globals": "11.3.0",
-				"invariant": "2.2.3",
+				"globals": "11.4.0",
+				"invariant": "2.2.4",
 				"lodash": "4.17.5"
 			},
 			"dependencies": {
 				"babylon": {
-					"version": "7.0.0-beta.40",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+					"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
 				},
 				"debug": {
 					"version": "3.1.0",
@@ -133,16 +142,16 @@
 					}
 				},
 				"globals": {
-					"version": "11.3.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-					"integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw=="
+					"version": "11.4.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+					"integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
 				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.0.0-beta.40",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
-			"integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
 			"requires": {
 				"esutils": "2.0.2",
 				"lodash": "4.17.5",
@@ -158,16 +167,16 @@
 		},
 		"@sinonjs/formatio": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
 			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
 			"requires": {
 				"samsam": "1.3.0"
 			}
 		},
 		"acorn": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-			"integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
@@ -201,9 +210,9 @@
 			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
 		},
 		"ansi-escapes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
@@ -254,7 +263,7 @@
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 			"requires": {
 				"define-properties": "1.1.2",
-				"es-abstract": "1.10.0"
+				"es-abstract": "1.11.0"
 			}
 		},
 		"array-union": {
@@ -307,7 +316,7 @@
 				"babel-register": "6.26.0",
 				"babel-runtime": "6.26.0",
 				"chokidar": "1.7.0",
-				"commander": "2.14.1",
+				"commander": "2.15.1",
 				"convert-source-map": "1.5.1",
 				"fs-readdir-recursive": "1.1.0",
 				"glob": "7.1.2",
@@ -357,21 +366,21 @@
 		},
 		"babel-eslint": {
 			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+			"resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
 			"integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.40",
-				"@babel/traverse": "7.0.0-beta.40",
-				"@babel/types": "7.0.0-beta.40",
-				"babylon": "7.0.0-beta.40",
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/traverse": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
 				"eslint-scope": "3.7.1",
 				"eslint-visitor-keys": "1.0.0"
 			},
 			"dependencies": {
 				"babylon": {
-					"version": "7.0.0-beta.40",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-					"integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+					"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
 				}
 			}
 		},
@@ -895,7 +904,7 @@
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
 			"requires": {
 				"babel-runtime": "6.26.0",
-				"core-js": "2.5.3",
+				"core-js": "2.5.4",
 				"regenerator-runtime": "0.10.5"
 			},
 			"dependencies": {
@@ -939,7 +948,7 @@
 				"babel-plugin-transform-exponentiation-operator": "6.24.1",
 				"babel-plugin-transform-regenerator": "6.26.0",
 				"browserslist": "2.11.3",
-				"invariant": "2.2.3",
+				"invariant": "2.2.4",
 				"semver": "5.5.0"
 			}
 		},
@@ -983,7 +992,7 @@
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-runtime": "6.26.0",
-				"core-js": "2.5.3",
+				"core-js": "2.5.4",
 				"home-or-tmp": "2.0.0",
 				"lodash": "4.17.5",
 				"mkdirp": "0.5.1",
@@ -995,7 +1004,7 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "2.5.3",
+				"core-js": "2.5.4",
 				"regenerator-runtime": "0.11.1"
 			}
 		},
@@ -1023,7 +1032,7 @@
 				"babylon": "6.18.0",
 				"debug": "2.6.9",
 				"globals": "9.18.0",
-				"invariant": "2.2.3",
+				"invariant": "2.2.4",
 				"lodash": "4.17.5"
 			}
 		},
@@ -1084,9 +1093,14 @@
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
 			"requires": {
-				"caniuse-lite": "1.0.30000811",
-				"electron-to-chromium": "1.3.34"
+				"caniuse-lite": "1.0.30000823",
+				"electron-to-chromium": "1.3.42"
 			}
+		},
+		"buffer-from": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
 		},
 		"caller-path": {
 			"version": "0.1.0",
@@ -1102,9 +1116,9 @@
 			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000811",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000811.tgz",
-			"integrity": "sha512-IPqVics/FqTQqdgcUZLTIe4BBwK3ndvzrAP7NX2meM3kk/w3oGivwWXJ5yvh2PXhWsU6VIKOM4dZCYKgNFh5tg=="
+			"version": "1.0.30000823",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000823.tgz",
+			"integrity": "sha512-3rrhqUxwBgrwNlWVUEwIJfqdZNwLPX18eTo7MGXb3gueDpbOFW6w5OXyHscdBd6IJcu9wnKmKVd7nSl+r7fmgw=="
 		},
 		"chai": {
 			"version": "4.1.2",
@@ -1195,9 +1209,9 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"commander": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1205,12 +1219,13 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
+				"buffer-from": "1.0.0",
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.5",
+				"readable-stream": "2.3.6",
 				"typedarray": "0.0.6"
 			}
 		},
@@ -1220,9 +1235,9 @@
 			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"core-js": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+			"integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1234,7 +1249,7 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"requires": {
-				"lru-cache": "4.1.1",
+				"lru-cache": "4.1.2",
 				"shebang-command": "1.2.0",
 				"which": "1.3.0"
 			}
@@ -1276,7 +1291,7 @@
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.1",
 				"object-assign": "4.1.1",
 				"pify": "2.3.0",
 				"pinkie-promise": "2.0.1",
@@ -1350,9 +1365,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.34",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.34.tgz",
-			"integrity": "sha1-2TSY9AORuwwWpgPYJBuZUUBBV+0="
+			"version": "1.3.42",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
+			"integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk="
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -1363,9 +1378,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.1",
@@ -1390,31 +1405,31 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint": {
-			"version": "4.18.2",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
-			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+			"version": "4.19.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"requires": {
 				"ajv": "5.5.2",
 				"babel-code-frame": "6.26.0",
 				"chalk": "2.3.2",
-				"concat-stream": "1.6.1",
+				"concat-stream": "1.6.2",
 				"cross-spawn": "5.1.0",
 				"debug": "3.1.0",
 				"doctrine": "2.1.0",
 				"eslint-scope": "3.7.1",
 				"eslint-visitor-keys": "1.0.0",
-				"espree": "3.5.3",
-				"esquery": "1.0.0",
+				"espree": "3.5.4",
+				"esquery": "1.0.1",
 				"esutils": "2.0.2",
 				"file-entry-cache": "2.0.0",
 				"functional-red-black-tree": "1.0.1",
 				"glob": "7.1.2",
-				"globals": "11.3.0",
+				"globals": "11.4.0",
 				"ignore": "3.3.7",
 				"imurmurhash": "0.1.4",
 				"inquirer": "3.3.0",
 				"is-resolvable": "1.1.0",
-				"js-yaml": "3.10.0",
+				"js-yaml": "3.11.0",
 				"json-stable-stringify-without-jsonify": "1.0.1",
 				"levn": "0.3.0",
 				"lodash": "4.17.5",
@@ -1425,6 +1440,7 @@
 				"path-is-inside": "1.0.2",
 				"pluralize": "7.0.0",
 				"progress": "2.0.0",
+				"regexpp": "1.1.0",
 				"require-uncached": "1.0.3",
 				"semver": "5.5.0",
 				"strip-ansi": "4.0.0",
@@ -1465,9 +1481,9 @@
 					}
 				},
 				"globals": {
-					"version": "11.3.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-					"integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw=="
+					"version": "11.4.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+					"integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
@@ -1513,11 +1529,11 @@
 			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
 		},
 		"espree": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
-			"integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"requires": {
-				"acorn": "5.5.0",
+				"acorn": "5.5.3",
 				"acorn-jsx": "3.0.1"
 			}
 		},
@@ -1527,9 +1543,9 @@
 			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"esquery": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1571,9 +1587,9 @@
 			}
 		},
 		"external-editor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"requires": {
 				"chardet": "0.4.2",
 				"iconv-lite": "0.4.19",
@@ -1728,7 +1744,7 @@
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
-				"nan": "2.9.2",
+				"nan": "2.10.0",
 				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
@@ -2659,11 +2675,11 @@
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"requires": {
-				"ansi-escapes": "3.0.0",
+				"ansi-escapes": "3.1.0",
 				"chalk": "2.3.2",
 				"cli-cursor": "2.1.0",
 				"cli-width": "2.2.0",
-				"external-editor": "2.1.0",
+				"external-editor": "2.2.0",
 				"figures": "2.0.0",
 				"lodash": "4.17.5",
 				"mute-stream": "0.0.7",
@@ -2717,9 +2733,9 @@
 			}
 		},
 		"invariant": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -2810,9 +2826,9 @@
 			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
 		},
 		"is-path-in-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"requires": {
 				"is-path-inside": "1.0.1"
 			}
@@ -2890,7 +2906,7 @@
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
 				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.3"
+				"whatwg-fetch": "2.0.4"
 			}
 		},
 		"js-tokens": {
@@ -2899,9 +2915,9 @@
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.0"
@@ -2963,9 +2979,9 @@
 			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
 		},
 		"lodash-es": {
-			"version": "4.17.5",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+			"version": "4.17.8",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.8.tgz",
+			"integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA=="
 		},
 		"lodash._basefor": {
 			"version": "3.0.3",
@@ -3001,16 +3017,6 @@
 				"lodash.isarray": "3.0.4"
 			}
 		},
-		"lodash.mergewith": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
-		},
-		"lodash.set": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-		},
 		"lolex": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
@@ -3025,9 +3031,9 @@
 			}
 		},
 		"lru-cache": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -3136,9 +3142,9 @@
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
-			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
 			"optional": true
 		},
 		"natural-compare": {
@@ -3147,9 +3153,9 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"nise": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
-			"integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
+			"integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"just-extend": "1.1.27",
@@ -3181,9 +3187,9 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nyc": {
-			"version": "11.4.1",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
-			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
+			"integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
 			"requires": {
 				"archy": "1.0.0",
 				"arrify": "1.0.1",
@@ -3195,23 +3201,23 @@
 				"find-up": "2.1.0",
 				"foreground-child": "1.5.6",
 				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.1.1",
+				"istanbul-lib-coverage": "1.2.0",
 				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.9.1",
-				"istanbul-lib-report": "1.1.2",
-				"istanbul-lib-source-maps": "1.2.2",
-				"istanbul-reports": "1.1.3",
+				"istanbul-lib-instrument": "1.10.1",
+				"istanbul-lib-report": "1.1.3",
+				"istanbul-lib-source-maps": "1.2.3",
+				"istanbul-reports": "1.3.0",
 				"md5-hex": "1.3.0",
-				"merge-source-map": "1.0.4",
+				"merge-source-map": "1.1.0",
 				"micromatch": "2.3.11",
 				"mkdirp": "0.5.1",
 				"resolve-from": "2.0.0",
 				"rimraf": "2.6.2",
 				"signal-exit": "3.0.2",
 				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.1.1",
-				"yargs": "10.0.3",
-				"yargs-parser": "8.0.0"
+				"test-exclude": "4.2.1",
+				"yargs": "11.1.0",
+				"yargs-parser": "8.1.0"
 			},
 			"dependencies": {
 				"align-text": {
@@ -3257,6 +3263,10 @@
 					"version": "1.1.0",
 					"bundled": true
 				},
+				"arr-union": {
+					"version": "3.1.0",
+					"bundled": true
+				},
 				"array-unique": {
 					"version": "0.2.1",
 					"bundled": true
@@ -3265,8 +3275,16 @@
 					"version": "1.0.1",
 					"bundled": true
 				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"bundled": true
+				},
 				"async": {
 					"version": "1.5.2",
+					"bundled": true
+				},
+				"atob": {
+					"version": "2.0.3",
 					"bundled": true
 				},
 				"babel-code-frame": {
@@ -3279,7 +3297,7 @@
 					}
 				},
 				"babel-generator": {
-					"version": "6.26.0",
+					"version": "6.26.1",
 					"bundled": true,
 					"requires": {
 						"babel-messages": "6.23.0",
@@ -3287,7 +3305,7 @@
 						"babel-types": "6.26.0",
 						"detect-indent": "4.0.0",
 						"jsesc": "1.3.0",
-						"lodash": "4.17.4",
+						"lodash": "4.17.5",
 						"source-map": "0.5.7",
 						"trim-right": "1.0.1"
 					}
@@ -3315,7 +3333,7 @@
 						"babel-traverse": "6.26.0",
 						"babel-types": "6.26.0",
 						"babylon": "6.18.0",
-						"lodash": "4.17.4"
+						"lodash": "4.17.5"
 					}
 				},
 				"babel-traverse": {
@@ -3329,8 +3347,8 @@
 						"babylon": "6.18.0",
 						"debug": "2.6.9",
 						"globals": "9.18.0",
-						"invariant": "2.2.2",
-						"lodash": "4.17.4"
+						"invariant": "2.2.3",
+						"lodash": "4.17.5"
 					}
 				},
 				"babel-types": {
@@ -3339,7 +3357,7 @@
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"esutils": "2.0.2",
-						"lodash": "4.17.4",
+						"lodash": "4.17.5",
 						"to-fast-properties": "1.0.3"
 					}
 				},
@@ -3351,8 +3369,34 @@
 					"version": "1.0.0",
 					"bundled": true
 				},
+				"base": {
+					"version": "0.11.2",
+					"bundled": true,
+					"requires": {
+						"cache-base": "1.0.1",
+						"class-utils": "0.3.6",
+						"component-emitter": "1.2.1",
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"mixin-deep": "1.3.1",
+						"pascalcase": "0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
 				"brace-expansion": {
-					"version": "1.1.8",
+					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
 						"balanced-match": "1.0.0",
@@ -3371,6 +3415,27 @@
 				"builtin-modules": {
 					"version": "1.1.1",
 					"bundled": true
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"collection-visit": "1.0.0",
+						"component-emitter": "1.2.1",
+						"get-value": "2.0.6",
+						"has-value": "1.0.0",
+						"isobject": "3.0.1",
+						"set-value": "2.0.0",
+						"to-object-path": "0.3.0",
+						"union-value": "1.0.0",
+						"unset-value": "1.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
 				},
 				"caching-transform": {
 					"version": "1.0.1",
@@ -3406,6 +3471,74 @@
 						"supports-color": "2.0.0"
 					}
 				},
+				"class-utils": {
+					"version": "0.3.6",
+					"bundled": true,
+					"requires": {
+						"arr-union": "3.1.0",
+						"define-property": "0.2.5",
+						"isobject": "3.0.1",
+						"static-extend": "0.1.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
@@ -3427,8 +3560,20 @@
 					"version": "1.1.0",
 					"bundled": true
 				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"map-visit": "1.0.0",
+						"object-visit": "1.0.1"
+					}
+				},
 				"commondir": {
 					"version": "1.0.1",
+					"bundled": true
+				},
+				"component-emitter": {
+					"version": "1.2.1",
 					"bundled": true
 				},
 				"concat-map": {
@@ -3439,6 +3584,10 @@
 					"version": "1.5.1",
 					"bundled": true
 				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"bundled": true
+				},
 				"core-js": {
 					"version": "2.5.3",
 					"bundled": true
@@ -3447,7 +3596,7 @@
 					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "4.1.1",
+						"lru-cache": "4.1.2",
 						"which": "1.3.0"
 					}
 				},
@@ -3466,11 +3615,29 @@
 					"version": "1.2.0",
 					"bundled": true
 				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true
+				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
 						"strip-bom": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"is-descriptor": "1.0.2",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
 					}
 				},
 				"detect-indent": {
@@ -3512,7 +3679,7 @@
 							"version": "5.1.0",
 							"bundled": true,
 							"requires": {
-								"lru-cache": "4.1.1",
+								"lru-cache": "4.1.2",
 								"shebang-command": "1.2.0",
 								"which": "1.3.0"
 							}
@@ -3531,6 +3698,23 @@
 					"bundled": true,
 					"requires": {
 						"fill-range": "2.2.3"
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
 					}
 				},
 				"extglob": {
@@ -3590,6 +3774,13 @@
 						"signal-exit": "3.0.2"
 					}
 				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"bundled": true,
+					"requires": {
+						"map-cache": "0.2.2"
+					}
+				},
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true
@@ -3600,6 +3791,10 @@
 				},
 				"get-stream": {
 					"version": "3.0.0",
+					"bundled": true
+				},
+				"get-value": {
+					"version": "2.0.6",
 					"bundled": true
 				},
 				"glob": {
@@ -3667,8 +3862,56 @@
 					"version": "1.0.0",
 					"bundled": true
 				},
+				"has-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"get-value": "2.0.6",
+						"has-values": "1.0.0",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
 				"hosted-git-info": {
-					"version": "2.5.0",
+					"version": "2.6.0",
 					"bundled": true
 				},
 				"imurmurhash": {
@@ -3688,7 +3931,7 @@
 					"bundled": true
 				},
 				"invariant": {
-					"version": "2.2.2",
+					"version": "2.2.3",
 					"bundled": true,
 					"requires": {
 						"loose-envify": "1.3.1"
@@ -3697,6 +3940,19 @@
 				"invert-kv": {
 					"version": "1.0.0",
 					"bundled": true
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
@@ -3711,6 +3967,34 @@
 					"bundled": true,
 					"requires": {
 						"builtin-modules": "1.1.1"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
 					}
 				},
 				"is-dotfile": {
@@ -3740,11 +4024,8 @@
 					}
 				},
 				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
+					"version": "2.0.0",
+					"bundled": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
@@ -3758,6 +4039,32 @@
 					"bundled": true,
 					"requires": {
 						"kind-of": "3.2.2"
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
 					}
 				},
 				"is-posix-bracket": {
@@ -3776,6 +4083,10 @@
 					"version": "0.2.1",
 					"bundled": true
 				},
+				"is-windows": {
+					"version": "1.0.2",
+					"bundled": true
+				},
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true
@@ -3792,7 +4103,7 @@
 					}
 				},
 				"istanbul-lib-coverage": {
-					"version": "1.1.1",
+					"version": "1.2.0",
 					"bundled": true
 				},
 				"istanbul-lib-hook": {
@@ -3803,23 +4114,23 @@
 					}
 				},
 				"istanbul-lib-instrument": {
-					"version": "1.9.1",
+					"version": "1.10.1",
 					"bundled": true,
 					"requires": {
-						"babel-generator": "6.26.0",
+						"babel-generator": "6.26.1",
 						"babel-template": "6.26.0",
 						"babel-traverse": "6.26.0",
 						"babel-types": "6.26.0",
 						"babylon": "6.18.0",
-						"istanbul-lib-coverage": "1.1.1",
-						"semver": "5.4.1"
+						"istanbul-lib-coverage": "1.2.0",
+						"semver": "5.5.0"
 					}
 				},
 				"istanbul-lib-report": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.1.1",
+						"istanbul-lib-coverage": "1.2.0",
 						"mkdirp": "0.5.1",
 						"path-parse": "1.0.5",
 						"supports-color": "3.2.3"
@@ -3835,11 +4146,11 @@
 					}
 				},
 				"istanbul-lib-source-maps": {
-					"version": "1.2.2",
+					"version": "1.2.3",
 					"bundled": true,
 					"requires": {
 						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.1.1",
+						"istanbul-lib-coverage": "1.2.0",
 						"mkdirp": "0.5.1",
 						"rimraf": "2.6.2",
 						"source-map": "0.5.7"
@@ -3855,7 +4166,7 @@
 					}
 				},
 				"istanbul-reports": {
-					"version": "1.1.3",
+					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
 						"handlebars": "4.0.11"
@@ -3914,7 +4225,7 @@
 					}
 				},
 				"lodash": {
-					"version": "4.17.4",
+					"version": "4.17.5",
 					"bundled": true
 				},
 				"longest": {
@@ -3929,11 +4240,22 @@
 					}
 				},
 				"lru-cache": {
-					"version": "4.1.1",
+					"version": "4.1.2",
 					"bundled": true,
 					"requires": {
 						"pseudomap": "1.0.2",
 						"yallist": "2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"bundled": true
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"object-visit": "1.0.1"
 					}
 				},
 				"md5-hex": {
@@ -3951,14 +4273,20 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"mimic-fn": "1.1.0"
+						"mimic-fn": "1.2.0"
 					}
 				},
 				"merge-source-map": {
-					"version": "1.0.4",
+					"version": "1.1.0",
 					"bundled": true,
 					"requires": {
-						"source-map": "0.5.7"
+						"source-map": "0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true
+						}
 					}
 				},
 				"micromatch": {
@@ -3981,19 +4309,36 @@
 					}
 				},
 				"mimic-fn": {
-					"version": "1.1.0",
+					"version": "1.2.0",
 					"bundled": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"for-in": "1.0.2",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
+					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
@@ -4006,14 +4351,46 @@
 					"version": "2.0.0",
 					"bundled": true
 				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"fragment-cache": "0.2.1",
+						"is-odd": "2.0.0",
+						"is-windows": "1.0.2",
+						"kind-of": "6.0.2",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "2.5.0",
+						"hosted-git-info": "2.6.0",
 						"is-builtin-module": "1.0.0",
-						"semver": "5.4.1",
-						"validate-npm-package-license": "3.0.1"
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.3"
 					}
 				},
 				"normalize-path": {
@@ -4038,12 +4415,85 @@
 					"version": "4.1.1",
 					"bundled": true
 				},
+				"object-copy": {
+					"version": "0.1.0",
+					"bundled": true,
+					"requires": {
+						"copy-descriptor": "0.1.1",
+						"define-property": "0.2.5",
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "5.1.0",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
 				"object.omit": {
 					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
 						"for-own": "0.1.5",
 						"is-extendable": "0.1.1"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
 					}
 				},
 				"once": {
@@ -4079,15 +4529,22 @@
 					"bundled": true
 				},
 				"p-limit": {
-					"version": "1.1.0",
-					"bundled": true
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"p-try": "1.0.0"
+					}
 				},
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
-						"p-limit": "1.1.0"
+						"p-limit": "1.2.0"
 					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"bundled": true
 				},
 				"parse-glob": {
 					"version": "3.0.4",
@@ -4105,6 +4562,10 @@
 					"requires": {
 						"error-ex": "1.3.1"
 					}
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"bundled": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
@@ -4165,6 +4626,10 @@
 							}
 						}
 					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"bundled": true
 				},
 				"preserve": {
 					"version": "0.2.0",
@@ -4245,6 +4710,14 @@
 						"is-equal-shallow": "0.1.3"
 					}
 				},
+				"regex-not": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "3.0.2",
+						"safe-regex": "1.1.0"
+					}
+				},
 				"remove-trailing-separator": {
 					"version": "1.1.0",
 					"bundled": true
@@ -4276,6 +4749,14 @@
 					"version": "2.0.0",
 					"bundled": true
 				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"ret": {
+					"version": "0.1.15",
+					"bundled": true
+				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
@@ -4291,13 +4772,39 @@
 						"glob": "7.1.2"
 					}
 				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"ret": "0.1.15"
+					}
+				},
 				"semver": {
-					"version": "5.4.1",
+					"version": "5.5.0",
 					"bundled": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"split-string": "3.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
 				},
 				"shebang-command": {
 					"version": "1.2.0",
@@ -4318,8 +4825,127 @@
 					"version": "1.1.6",
 					"bundled": true
 				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"bundled": true,
+					"requires": {
+						"base": "0.11.2",
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"map-cache": "0.2.2",
+						"source-map": "0.5.7",
+						"source-map-resolve": "0.5.1",
+						"use": "3.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"snapdragon-util": "3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
 				"source-map": {
 					"version": "0.5.7",
+					"bundled": true
+				},
+				"source-map-resolve": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"atob": "2.0.3",
+						"decode-uri-component": "0.2.0",
+						"resolve-url": "0.2.1",
+						"source-map-url": "0.4.0",
+						"urix": "0.1.0"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
 					"bundled": true
 				},
 				"spawn-wrap": {
@@ -4335,19 +4961,97 @@
 					}
 				},
 				"spdx-correct": {
-					"version": "1.0.2",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-license-ids": "1.2.2"
+						"spdx-expression-parse": "3.0.0",
+						"spdx-license-ids": "3.0.0"
 					}
 				},
-				"spdx-expression-parse": {
-					"version": "1.0.4",
+				"spdx-exceptions": {
+					"version": "2.1.0",
 					"bundled": true
 				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-exceptions": "2.1.0",
+						"spdx-license-ids": "3.0.0"
+					}
+				},
 				"spdx-license-ids": {
-					"version": "1.2.2",
+					"version": "3.0.0",
 					"bundled": true
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "3.0.2"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "0.2.5",
+						"object-copy": "0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
 				},
 				"string-width": {
 					"version": "2.1.1",
@@ -4359,10 +5063,6 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
 							"bundled": true
 						},
 						"strip-ansi": {
@@ -4397,19 +5097,263 @@
 					"bundled": true
 				},
 				"test-exclude": {
-					"version": "4.1.1",
+					"version": "4.2.1",
 					"bundled": true,
 					"requires": {
 						"arrify": "1.0.1",
-						"micromatch": "2.3.11",
+						"micromatch": "3.1.9",
 						"object-assign": "4.1.1",
 						"read-pkg-up": "1.0.1",
 						"require-main-filename": "1.0.1"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"bundled": true
+						},
+						"braces": {
+							"version": "2.3.1",
+							"bundled": true,
+							"requires": {
+								"arr-flatten": "1.1.0",
+								"array-unique": "0.3.2",
+								"define-property": "1.0.0",
+								"extend-shallow": "2.0.1",
+								"fill-range": "4.0.0",
+								"isobject": "3.0.1",
+								"kind-of": "6.0.2",
+								"repeat-element": "1.1.2",
+								"snapdragon": "0.8.2",
+								"snapdragon-node": "2.1.1",
+								"split-string": "3.1.0",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "1.0.2"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"expand-brackets": {
+							"version": "2.1.4",
+							"bundled": true,
+							"requires": {
+								"debug": "2.6.9",
+								"define-property": "0.2.5",
+								"extend-shallow": "2.0.1",
+								"posix-character-classes": "0.1.1",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "0.2.5",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "0.1.6"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								},
+								"is-descriptor": {
+									"version": "0.1.6",
+									"bundled": true,
+									"requires": {
+										"is-accessor-descriptor": "0.1.6",
+										"is-data-descriptor": "0.1.4",
+										"kind-of": "5.1.0"
+									}
+								},
+								"kind-of": {
+									"version": "5.1.0",
+									"bundled": true
+								}
+							}
+						},
+						"extglob": {
+							"version": "2.0.4",
+							"bundled": true,
+							"requires": {
+								"array-unique": "0.3.2",
+								"define-property": "1.0.0",
+								"expand-brackets": "2.1.4",
+								"extend-shallow": "2.0.1",
+								"fragment-cache": "0.2.1",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "1.0.2"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"fill-range": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "2.0.1",
+								"is-number": "3.0.0",
+								"repeat-string": "1.6.1",
+								"to-regex-range": "2.1.1"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						},
+						"micromatch": {
+							"version": "3.1.9",
+							"bundled": true,
+							"requires": {
+								"arr-diff": "4.0.0",
+								"array-unique": "0.3.2",
+								"braces": "2.3.1",
+								"define-property": "2.0.2",
+								"extend-shallow": "3.0.2",
+								"extglob": "2.0.4",
+								"fragment-cache": "0.2.1",
+								"kind-of": "6.0.2",
+								"nanomatch": "1.2.9",
+								"object.pick": "1.3.0",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							}
+						}
 					}
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
 					"bundled": true
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"regex-not": "1.0.2",
+						"safe-regex": "1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						}
+					}
 				},
 				"trim-right": {
 					"version": "1.0.1",
@@ -4443,12 +5387,94 @@
 					"bundled": true,
 					"optional": true
 				},
-				"validate-npm-package-license": {
-					"version": "3.0.1",
+				"union-value": {
+					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"spdx-correct": "1.0.2",
-						"spdx-expression-parse": "1.0.4"
+						"arr-union": "3.1.0",
+						"get-value": "2.0.6",
+						"is-extendable": "0.1.1",
+						"set-value": "0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "2.0.1",
+								"is-extendable": "0.1.1",
+								"is-plain-object": "2.0.4",
+								"to-object-path": "0.3.0"
+							}
+						}
+					}
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"has-value": "0.3.1",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"bundled": true,
+							"requires": {
+								"get-value": "2.0.6",
+								"has-values": "0.1.4",
+								"isobject": "2.1.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"bundled": true
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"bundled": true
+				},
+				"use": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "3.0.0",
+						"spdx-expression-parse": "3.0.0"
 					}
 				},
 				"which": {
@@ -4479,6 +5505,13 @@
 						"strip-ansi": "3.0.1"
 					},
 					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "1.0.1"
+							}
+						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
@@ -4512,10 +5545,10 @@
 					"bundled": true
 				},
 				"yargs": {
-					"version": "10.0.3",
+					"version": "11.1.0",
 					"bundled": true,
 					"requires": {
-						"cliui": "3.2.0",
+						"cliui": "4.0.0",
 						"decamelize": "1.2.0",
 						"find-up": "2.1.0",
 						"get-caller-file": "1.0.2",
@@ -4526,33 +5559,44 @@
 						"string-width": "2.1.1",
 						"which-module": "2.0.0",
 						"y18n": "3.2.1",
-						"yargs-parser": "8.0.0"
+						"yargs-parser": "9.0.2"
 					},
 					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						},
 						"cliui": {
-							"version": "3.2.0",
+							"version": "4.0.0",
 							"bundled": true,
 							"requires": {
-								"string-width": "1.0.2",
-								"strip-ansi": "3.0.1",
+								"string-width": "2.1.1",
+								"strip-ansi": "4.0.0",
 								"wrap-ansi": "2.1.0"
-							},
-							"dependencies": {
-								"string-width": {
-									"version": "1.0.2",
-									"bundled": true,
-									"requires": {
-										"code-point-at": "1.1.0",
-										"is-fullwidth-code-point": "1.0.0",
-										"strip-ansi": "3.0.1"
-									}
-								}
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						},
+						"yargs-parser": {
+							"version": "9.0.2",
+							"bundled": true,
+							"requires": {
+								"camelcase": "4.1.0"
 							}
 						}
 					}
 				},
 				"yargs-parser": {
-					"version": "8.0.0",
+					"version": "8.1.0",
 					"bundled": true,
 					"requires": {
 						"camelcase": "4.1.0"
@@ -4791,16 +5835,16 @@
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
 				"isarray": "1.0.0",
 				"process-nextick-args": "2.0.0",
 				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
+				"string_decoder": "1.1.1",
 				"util-deprecate": "1.0.2"
 			}
 		},
@@ -4812,7 +5856,7 @@
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"minimatch": "3.0.4",
-				"readable-stream": "2.3.5",
+				"readable-stream": "2.3.6",
 				"set-immediate-shim": "1.0.1"
 			}
 		},
@@ -4822,7 +5866,7 @@
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
 			"requires": {
 				"lodash": "4.17.5",
-				"lodash-es": "4.17.5",
+				"lodash-es": "4.17.8",
 				"loose-envify": "1.3.1",
 				"symbol-observable": "1.2.0"
 			}
@@ -4884,6 +5928,11 @@
 			"requires": {
 				"is-equal-shallow": "0.1.3"
 			}
+		},
+		"regexpp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
 		},
 		"regexpu-core": {
 			"version": "2.0.0",
@@ -5036,15 +6085,15 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"sinon": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
-			"integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+			"integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
 			"requires": {
 				"@sinonjs/formatio": "2.0.0",
 				"diff": "3.3.1",
 				"lodash.get": "4.4.2",
 				"lolex": "2.3.2",
-				"nise": "1.3.0",
+				"nise": "1.3.2",
 				"supports-color": "5.3.0",
 				"type-detect": "4.0.8"
 			},
@@ -5120,9 +6169,9 @@
 			}
 		},
 		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -5243,9 +6292,9 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"typescript": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-			"integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+			"integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg=="
 		},
 		"typescript-definition-tester": {
 			"version": "0.0.5",
@@ -5288,9 +6337,9 @@
 			}
 		},
 		"whatwg-fetch": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"which": {
 			"version": "1.3.0",

--- a/packages/redux-dynamic-reducer/package.json
+++ b/packages/redux-dynamic-reducer/package.json
@@ -20,8 +20,6 @@
   },
   "dependencies": {
     "lodash.isplainobject": "^4.0.6",
-    "lodash.mergewith": "^4.6.0",
-    "lodash.set": "^4.3.2",
     "redux-concatenate-reducers": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/redux-dynamic-reducer/src/flattenReducers.js
+++ b/packages/redux-dynamic-reducer/src/flattenReducers.js
@@ -8,14 +8,16 @@
 
 const flattenReducers = (reducers, parentKey) => {
   if (typeof reducers === 'function') {
-    return { [parentKey.replace('/', '.')]: reducers }
+    return { [parentKey.replace(/\//g, '.')]: reducers }
   }
 
-  return Object.keys(reducers)
-    .reduce((reducerMap, key) => ({
+  return Object.keys(reducers).reduce(
+    (reducerMap, key) => ({
       ...reducerMap,
       ...flattenReducers(reducers[key], parentKey ? `${parentKey}.${key}` : key)
-    }), {})
+    }),
+    {}
+  )
 }
 
 export default flattenReducers

--- a/packages/redux-dynamic-reducer/test/createDynamicReducer-spec.js
+++ b/packages/redux-dynamic-reducer/test/createDynamicReducer-spec.js
@@ -9,117 +9,149 @@
 import { combineReducers } from 'redux'
 import createDynamicReducer from '../src/createDynamicReducer'
 
-describe('nestedCombineReducers tests', () => {
+describe('createDynamicReducer tests', () => {
+  const reducer1 = (state = 'test1', action) => action.value1 || state
+  const reducer2 = (state = 'test2', action) => action.value2 || state
 
-    const reducer1 = (state = "test1", action) => action.value1 || state
-    const reducer2 = (state = "test2", action) => action.value2 || state
-
-    it('should combine reducers in single level', () => {
-        const reducer = createDynamicReducer({
-            reducer1,
-            reducer2
-        })
-
-        const initialState = {
-            reducer1: "wrong",
-            reducer2: "wrong"
-        }
-
-        const actions = [
-            { value1: "expected1" },
-            { value2: "expected2" }
-        ]
-
-        const state = actions.reduce(reducer, initialState)
-
-        expect(state).to.deep.equal({
-            reducer1: "expected1",
-            reducer2: "expected2"
-        })
+  it('should combine reducers in single level', () => {
+    const reducer = createDynamicReducer({
+      reducer1,
+      reducer2
     })
-    
-    it('should combine reducers in nested levels', () => {
-        const reducer = createDynamicReducer({
-            'parent1.reducer1': reducer1,
-            'parent1.reducer2': reducer2,
-            'parent2.parent3.reducer1': reducer1,
-            'parent2.parent3.reducer2': reducer2,
-        })
 
-        const initialState = {
-            parent1: {
-                reducer1: "wrong", 
-                reducer2: "wrong"
-            },
-            parent2: {
-                parent3: {
-                    reducer1: "wrong", 
-                    reducer2: "wrong"
-                }
-            }
-        }
+    const initialState = {
+      reducer1: 'wrong',
+      reducer2: 'wrong'
+    }
 
-        const actions = [
-            { value1: "expected1" },
-            { value2: "expected2" }
-        ]
+    const actions = [{ value1: 'expected1' }, { value2: 'expected2' }]
 
-        const state = actions.reduce(reducer, initialState)
+    const state = actions.reduce(reducer, initialState)
 
-        expect(state).to.deep.equal({
-            parent1: {
-                reducer1: "expected1", 
-                reducer2: "expected2"
-            },
-            parent2: {
-                parent3: {
-                    reducer1: "expected1", 
-                    reducer2: "expected2"
-                }
-            }
-        })
+    expect(state).to.deep.equal({
+      reducer1: 'expected1',
+      reducer2: 'expected2'
     })
-    
-    it('should combine reducers in different nested levels', () => {
+  })
 
-        const reducer = createDynamicReducer({
-            'parent1': combineReducers({ reducer1 }),
-            'parent1.reducer2': reducer2,
-            'parent2.parent3': combineReducers({ reducer1 }),
-            'parent2.parent3.reducer2': reducer2,
-        })
-
-        const initialState = {
-            parent1: {
-                reducer1: "wrong", 
-                reducer2: "wrong"
-            },
-            parent2: {
-                "parent3": {
-                    reducer1: "wrong", 
-                    reducer2: "wrong"
-                }
-            }
-        }
-
-        const actions = [
-            { value1: "expected1" },
-            { value2: "expected2" }
-        ]
-
-        const state = actions.reduce(reducer, initialState)
-
-        expect(state).to.deep.equal({
-            parent1: {
-                reducer1: "expected1", 
-                reducer2: "expected2"
-            },
-            parent2: {
-                "parent3": {
-                    reducer1: "expected1", 
-                    reducer2: "expected2"
-                }
-            }
-        })
+  it('should combine reducers in nested levels', () => {
+    const reducer = createDynamicReducer({
+      'parent1.reducer1': reducer1,
+      'parent1.reducer2': reducer2,
+      'parent2.parent3.reducer1': reducer1,
+      'parent2.parent3.reducer2': reducer2
     })
+
+    const initialState = {
+      parent1: {
+        reducer1: 'wrong',
+        reducer2: 'wrong'
+      },
+      parent2: {
+        parent3: {
+          reducer1: 'wrong',
+          reducer2: 'wrong'
+        }
+      }
+    }
+
+    const actions = [{ value1: 'expected1' }, { value2: 'expected2' }]
+
+    const state = actions.reduce(reducer, initialState)
+
+    expect(state).to.deep.equal({
+      parent1: {
+        reducer1: 'expected1',
+        reducer2: 'expected2'
+      },
+      parent2: {
+        parent3: {
+          reducer1: 'expected1',
+          reducer2: 'expected2'
+        }
+      }
+    })
+  })
+
+  it('should combine reducers in different nested levels', () => {
+    const reducer = createDynamicReducer({
+      parent1: combineReducers({ reducer1 }),
+      'parent1.reducer2': reducer2,
+      'parent2.parent3': combineReducers({ reducer1 }),
+      'parent2.parent3.reducer2': reducer2
+    })
+
+    const initialState = {
+      parent1: {
+        reducer1: 'wrong',
+        reducer2: 'wrong'
+      },
+      parent2: {
+        parent3: {
+          reducer1: 'wrong',
+          reducer2: 'wrong'
+        }
+      }
+    }
+
+    const actions = [{ value1: 'expected1' }, { value2: 'expected2' }]
+
+    const state = actions.reduce(reducer, initialState)
+
+    expect(state).to.deep.equal({
+      parent1: {
+        reducer1: 'expected1',
+        reducer2: 'expected2'
+      },
+      parent2: {
+        parent3: {
+          reducer1: 'expected1',
+          reducer2: 'expected2'
+        }
+      }
+    })
+  })
+
+  it('should handle variety of nested levels', () => {
+    const dummyReducer = (state = { value: 0 }, action) =>
+      action.type === 'INC' ? { ...state, value: state.value + 1 } : state
+
+    const inputStructure = {
+      foo: dummyReducer,
+      'foo.bar': dummyReducer,
+      'foo.bar.baz': dummyReducer,
+      'foo.bar.qux': dummyReducer,
+      'foo.baz': dummyReducer,
+      bar: dummyReducer,
+      'bar.baz': dummyReducer
+    }
+
+    const reducer = createDynamicReducer(inputStructure)
+
+    const initialState = reducer(undefined, { type: 'INIT' })
+
+    expect(initialState).to.deep.equal({
+      foo: {
+        value: 0,
+        bar: {
+          value: 0,
+          baz: {
+            value: 0
+          },
+          qux: {
+            value: 0
+          }
+        },
+        baz: {
+          value: 0
+        }
+      },
+      bar: {
+        value: 0,
+        baz: {
+          value: 0
+        }
+      }
+    })
+  })
 })

--- a/packages/redux-dynamic-reducer/test/flattenReducers-spec.js
+++ b/packages/redux-dynamic-reducer/test/flattenReducers-spec.js
@@ -9,87 +9,89 @@
 import flattenReducers from '../src/flattenReducers'
 
 describe('flattenReducers Tests', () => {
-    const reducer = () => null
-    
-    it('should not change basic reducer structure', () => {
-        const reducers = {
-            parent1: reducer,
-            parent2: reducer
-        }
+  const reducer = () => null
 
-        const flattenedReducers = flattenReducers(reducers)
+  it('should not change basic reducer structure', () => {
+    const reducers = {
+      parent1: reducer,
+      parent2: reducer
+    }
 
-        expect(flattenedReducers).to.deep.equal({
-            parent1: reducer,
-            parent2: reducer
-        })
+    const flattenedReducers = flattenReducers(reducers)
+
+    expect(flattenedReducers).to.deep.equal({
+      parent1: reducer,
+      parent2: reducer
     })
+  })
 
-    it('should flatten reducer structure', () => {
-        const reducers = {
-            parent1: {
-                parent2: reducer
-            }
-        }
+  it('should flatten reducer structure', () => {
+    const reducers = {
+      parent1: {
+        parent2: reducer
+      }
+    }
 
-        const flattenedReducers = flattenReducers(reducers)
+    const flattenedReducers = flattenReducers(reducers)
 
-        expect(flattenedReducers).to.deep.equal({
-            'parent1.parent2': reducer
-        })
+    expect(flattenedReducers).to.deep.equal({
+      'parent1.parent2': reducer
     })
+  })
 
-    it('should flatten deeply nested reducer structure', () => {
-        const reducers = {
-            parent1: {
-                parent2: {
-                    parent3: reducer
-                }
-            }
+  it('should flatten deeply nested reducer structure', () => {
+    const reducers = {
+      parent1: {
+        parent2: {
+          parent3: reducer
         }
+      }
+    }
 
-        const flattenedReducers = flattenReducers(reducers)
+    const flattenedReducers = flattenReducers(reducers)
 
-        expect(flattenedReducers).to.deep.equal({
-            'parent1.parent2.parent3': reducer
-        })
+    expect(flattenedReducers).to.deep.equal({
+      'parent1.parent2.parent3': reducer
     })
-    
-    it('should flatten differently nested reducer structure', () => {
-        const reducers = {
-            parent1: {
-                parent2: reducer,
-                parent3: reducer
-            },
-            parent3: {
-                parent4: reducer,
-                parent5: {
-                    parent6: reducer
-                }
-            },
-            parent7: reducer
+  })
+
+  it('should flatten differently nested reducer structure', () => {
+    const reducers = {
+      parent1: {
+        parent2: reducer,
+        parent3: reducer
+      },
+      parent3: {
+        parent4: reducer,
+        parent5: {
+          parent6: reducer
         }
+      },
+      parent7: reducer
+    }
 
-        const flattenedReducers = flattenReducers(reducers)
+    const flattenedReducers = flattenReducers(reducers)
 
-        expect(flattenedReducers).to.deep.equal({
-            'parent1.parent2': reducer,
-            'parent1.parent3': reducer,
-            'parent3.parent4': reducer,
-            'parent3.parent5.parent6': reducer,
-            'parent7': reducer
-        })
+    expect(flattenedReducers).to.deep.equal({
+      'parent1.parent2': reducer,
+      'parent1.parent3': reducer,
+      'parent3.parent4': reducer,
+      'parent3.parent5.parent6': reducer,
+      parent7: reducer
     })
-    
-    it('should normalize nested path seperator', () => {
-        const reducers = {
-            'parent1/parent2': reducer
-        }
+  })
 
-        const flattenedReducers = flattenReducers(reducers)
+  it('should normalize nested path seperator', () => {
+    const reducers = {
+      'parent1/parent2': reducer,
+      'parent1/parent2/parent3': reducer
+    }
 
-        expect(flattenedReducers).to.deep.equal({
-            'parent1.parent2': reducer
-        })
+    const flattenedReducers = flattenReducers(reducers)
+
+    expect(flattenedReducers).to.deep.equal({
+      'parent1.parent2': reducer,
+      'parent1.parent2.parent3': reducer
     })
+  })
 })


### PR DESCRIPTION
The change to `createDynamicReducer` is what we are already using internally in `redux-dynostore` and fixes an issue that caused some dynamic reducers to vanish on some complex store structures.

The change to `flattenReducers` fixes the issue described in #12.